### PR TITLE
Mutable producer underlying client

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -244,6 +244,11 @@ impl Producer {
         &self.client
     }
 
+    /// Borrows the underlying kafka client as mut.
+    pub fn client_mut(&mut self) -> &mut KafkaClient {
+        &mut self.client
+    }
+
     /// Destroys this producer returning the underlying kafka client.
     pub fn into_client(self) -> KafkaClient {
         self.client


### PR DESCRIPTION
Adds a function to kafka producer to get the underlying client as mutable.

For the same reasons that were specified here: https://github.com/spicavigo/kafka-rust/pull/160. I need to be able to reload metadata on certain error types.