### PR TITLE
Remove all usage of `try!`

### DIFF
--- a/examples/example-consume.rs
+++ b/examples/example-consume.rs
@@ -1,5 +1,5 @@
-extern crate kafka;
 extern crate env_logger;
+extern crate kafka;
 
 use kafka::consumer::{Consumer, FetchOffset, GroupOffsetStorage};
 use kafka::error::Error as KafkaError;
@@ -21,17 +21,15 @@ fn main() {
 }
 
 fn consume_messages(group: String, topic: String, brokers: Vec<String>) -> Result<(), KafkaError> {
-    let mut con = try!(
-        Consumer::from_hosts(brokers)
-            .with_topic(topic)
-            .with_group(group)
-            .with_fallback_offset(FetchOffset::Earliest)
-            .with_offset_storage(GroupOffsetStorage::Kafka)
-            .create()
-    );
+    let mut con = Consumer::from_hosts(brokers)
+        .with_topic(topic)
+        .with_group(group)
+        .with_fallback_offset(FetchOffset::Earliest)
+        .with_offset_storage(GroupOffsetStorage::Kafka)
+        .create()?;
 
     loop {
-        let mss = try!(con.poll());
+        let mss = con.poll()?;
         if mss.is_empty() {
             println!("No messages available right now.");
             return Ok(());
@@ -39,10 +37,16 @@ fn consume_messages(group: String, topic: String, brokers: Vec<String>) -> Resul
 
         for ms in mss.iter() {
             for m in ms.messages() {
-                println!("{}:{}@{}: {:?}", ms.topic(), ms.partition(), m.offset, m.value);
+                println!(
+                    "{}:{}@{}: {:?}",
+                    ms.topic(),
+                    ms.partition(),
+                    m.offset,
+                    m.value
+                );
             }
             let _ = con.consume_messageset(ms);
         }
-        try!(con.commit_consumed());
+        con.commit_consumed()?;
     }
 }

--- a/examples/example-produce.rs
+++ b/examples/example-produce.rs
@@ -1,10 +1,10 @@
-extern crate kafka;
 extern crate env_logger;
+extern crate kafka;
 
 use std::time::Duration;
 
-use kafka::producer::{Producer, Record, RequiredAcks};
 use kafka::error::Error as KafkaError;
+use kafka::producer::{Producer, Record, RequiredAcks};
 
 /// This program demonstrates sending single message through a
 /// `Producer`.  This is a convenient higher-level client that will
@@ -32,15 +32,13 @@ fn produce_message<'a, 'b>(
     // ~ create a producer. this is a relatively costly operation, so
     // you'll do this typically once in your application and re-use
     // the instance many times.
-    let mut producer = try!(
-        Producer::from_hosts(brokers)
-             // ~ give the brokers one second time to ack the message
-             .with_ack_timeout(Duration::from_secs(1))
-             // ~ require only one broker to ack the message
-             .with_required_acks(RequiredAcks::One)
-             // ~ build the producer with the above settings
-             .create()
-    );
+    let mut producer = Producer::from_hosts(brokers)
+        // ~ give the brokers one second time to ack the message
+        .with_ack_timeout(Duration::from_secs(1))
+        // ~ require only one broker to ack the message
+        .with_required_acks(RequiredAcks::One)
+        // ~ build the producer with the above settings
+        .create()?;
 
     // ~ now send a single message.  this is a synchronous/blocking
     // operation.
@@ -51,16 +49,16 @@ fn produce_message<'a, 'b>(
     // ~ we leave the partition "unspecified" - this is a negative
     // partition - which causes the producer to find out one on its
     // own using its underlying partitioner.
-    try!(producer.send(&Record {
+    producer.send(&Record {
         topic: topic,
         partition: -1,
         key: (),
         value: data,
-    }));
+    })?;
 
     // ~ we can achieve exactly the same as above in a shorter way with
     // the following call
-    try!(producer.send(&Record::from_value(topic, data)));
+    producer.send(&Record::from_value(topic, data))?;
 
     Ok(())
 }

--- a/examples/offset-monitor.rs
+++ b/examples/offset-monitor.rs
@@ -1,6 +1,6 @@
-extern crate kafka;
-extern crate getopts;
 extern crate env_logger;
+extern crate getopts;
+extern crate kafka;
 extern crate time;
 #[macro_use]
 extern crate error_chain;
@@ -8,12 +8,12 @@ extern crate error_chain;
 use std::ascii::AsciiExt;
 use std::cmp;
 use std::env;
-use std::io::{self, stdout, stderr, BufWriter, Write};
+use std::io::{self, stderr, stdout, BufWriter, Write};
 use std::process;
 use std::thread;
 use std::time as stdtime;
 
-use kafka::client::{KafkaClient, FetchOffset, GroupOffsetStorage};
+use kafka::client::{FetchOffset, GroupOffsetStorage, KafkaClient};
 
 /// A very simple offset monitor for a particular topic able to show
 /// the lag for a particular consumer group. Dumps the offset/lag of
@@ -27,7 +27,7 @@ fn main() {
             let _ = write!(out, "error: {}\n", $e);
             let _ = out.flush();
             process::exit(1);
-        }}
+        }};
     };
 
     let cfg = match Config::from_cmdline() {
@@ -43,7 +43,7 @@ fn main() {
 fn run(cfg: Config) -> Result<()> {
     let mut client = KafkaClient::new(cfg.brokers.clone());
     client.set_group_offset_storage(cfg.offset_storage);
-    try!(client.load_metadata_all());
+    client.load_metadata_all()?;
 
     // ~ if no topic specified, print all available and be done.
     if cfg.topic.is_empty() {
@@ -70,18 +70,18 @@ fn run(cfg: Config) -> Result<()> {
     };
     let mut state = State::new(num_partitions, cfg.commited_not_consumed);
     let mut printer = Printer::new(stdout(), &cfg);
-    try!(printer.print_head(num_partitions));
+    printer.print_head(num_partitions)?;
 
     // ~ initialize the state
     let mut first_time = true;
     loop {
         let t = time::now();
-        try!(state.update_partitions(&mut client, &cfg.topic, &cfg.group));
+        state.update_partitions(&mut client, &cfg.topic, &cfg.group)?;
         if first_time {
             state.curr_to_prev();
             first_time = false;
         }
-        try!(printer.print_offsets(&t, &state.offsets));
+        printer.print_offsets(&t, &state.offsets)?;
         thread::sleep(cfg.period);
     }
 }
@@ -123,23 +123,25 @@ impl State {
         group: &str,
     ) -> Result<()> {
         // ~ get the latest topic offsets
-        let latests = try!(client.fetch_topic_offsets(topic, FetchOffset::Latest));
+        let latests = client.fetch_topic_offsets(topic, FetchOffset::Latest)?;
 
         for l in latests {
-            let off = self.offsets.get_mut(l.partition as usize).expect(
-                "[topic offset] non-existent partition",
-            );
+            let off = self
+                .offsets
+                .get_mut(l.partition as usize)
+                .expect("[topic offset] non-existent partition");
             off.prev_latest = off.curr_latest;
             off.curr_latest = l.offset;
         }
 
         if !group.is_empty() {
             // ~ get the current group offsets
-            let groups = try!(client.fetch_group_topic_offsets(group, topic));
+            let groups = client.fetch_group_topic_offsets(group, topic)?;
             for g in groups {
-                let off = self.offsets.get_mut(g.partition as usize).expect(
-                    "[group offset] non-existent partition",
-                );
+                let off = self
+                    .offsets
+                    .get_mut(g.partition as usize)
+                    .expect("[group offset] non-existent partition");
 
                 // ~ it's quite likely that we fetched group offsets
                 // which are a bit ahead of the topic's latest offset
@@ -223,7 +225,7 @@ impl<W: Write> Printer<W> {
         }
         {
             // ~ print
-            try!(self.out.write_all(self.out_buf.as_bytes()));
+            self.out.write_all(self.out_buf.as_bytes())?;
             Ok(())
         }
     }
@@ -235,8 +237,11 @@ impl<W: Write> Printer<W> {
             use std::fmt::Write;
 
             self.fmt_buf.clear();
-            let _ =
-                write!(self.fmt_buf, "{}", time.strftime(&self.timefmt).expect("invalid timefmt"));
+            let _ = write!(
+                self.fmt_buf,
+                "{}",
+                time.strftime(&self.timefmt).expect("invalid timefmt")
+            );
             let _ = write!(self.out_buf, "{1:<0$}", self.time_width, self.fmt_buf);
             if self.print_summary {
                 let mut prev_latest = 0;
@@ -246,9 +251,13 @@ impl<W: Write> Printer<W> {
                     macro_rules! cond_add {
                         ($v:ident) => {
                             if $v != -1 {
-                                if p.$v < 0 { $v = -1; } else { $v += p.$v; }
+                                if p.$v < 0 {
+                                    $v = -1;
+                                } else {
+                                    $v += p.$v;
+                                }
                             }
-                        }
+                        };
                     };
                     cond_add!(prev_latest);
                     cond_add!(curr_latest);
@@ -282,7 +291,7 @@ impl<W: Write> Printer<W> {
             }
         }
         self.out_buf.push('\n');
-        try!(self.out.write_all(self.out_buf.as_bytes()));
+        self.out.write_all(self.out_buf.as_bytes())?;
         Ok(())
     }
 }
@@ -305,19 +314,33 @@ impl Config {
         let args: Vec<String> = env::args().collect();
         let mut opts = getopts::Options::new();
         opts.optflag("h", "help", "Print this help screen");
-        opts.optopt("", "brokers", "Specify kafka bootstrap brokers (comma separated)", "HOSTS");
+        opts.optopt(
+            "",
+            "brokers",
+            "Specify kafka bootstrap brokers (comma separated)",
+            "HOSTS",
+        );
         opts.optopt("", "topic", "Specify the topic to monitor", "TOPIC");
         opts.optopt("", "group", "Specify the group to monitor", "GROUP");
-        opts.optopt("", "storage", "Specify offset store [zookeeper, kafka]", "STORE");
+        opts.optopt(
+            "",
+            "storage",
+            "Specify offset store [zookeeper, kafka]",
+            "STORE",
+        );
         opts.optopt("", "sleep", "Specify the sleep time", "SECS");
-        opts.optflag("", "partitions", "Print each partition instead of the summary");
+        opts.optflag(
+            "",
+            "partitions",
+            "Print each partition instead of the summary",
+        );
         opts.optflag("", "no-growth", "Don't print offset growth");
         opts.optflag(
             "",
             "committed-not-yet-consumed",
             "Assume commited group offsets specify \
-                      messages the group will start consuming \
-                      (including those at these offsets)",
+             messages the group will start consuming \
+             (including those at these offsets)",
         );
 
         let m = match opts.parse(&args[1..]) {
@@ -346,7 +369,8 @@ impl Config {
             }
         }
         Ok(Config {
-            brokers: m.opt_str("brokers")
+            brokers: m
+                .opt_str("brokers")
                 .unwrap_or_else(|| "localhost:9092".to_owned())
                 .split(',')
                 .map(|s| s.trim().to_owned())

--- a/src/client/metadata.rs
+++ b/src/client/metadata.rs
@@ -4,8 +4,8 @@
 use std::collections::hash_map;
 use std::fmt;
 
+use super::state::{ClientState, TopicPartition, TopicPartitionIter, TopicPartitions};
 use super::KafkaClient;
-use super::state::{ClientState, TopicPartitions, TopicPartitionIter, TopicPartition};
 
 // public re-export
 pub use super::state::Broker;
@@ -21,7 +21,9 @@ impl<'a> Topics<'a> {
     /// the specified kafka client.
     #[inline]
     pub fn new(client: &KafkaClient) -> Topics {
-        Topics { state: &client.state }
+        Topics {
+            state: &client.state,
+        }
     }
 
     /// Retrieves the number of the underlying topics.
@@ -53,24 +55,22 @@ impl<'a> Topics<'a> {
     /// Retrieves the partitions of a specified topic.
     #[inline]
     pub fn partitions(&'a self, topic: &str) -> Option<Partitions<'a>> {
-        self.state.partitions_for(topic).map(|tp| {
-            Partitions {
-                state: self.state,
-                tp: tp,
-            }
+        self.state.partitions_for(topic).map(|tp| Partitions {
+            state: self.state,
+            tp: tp,
         })
     }
 }
 
 impl<'a> fmt::Debug for Topics<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "Topics {{ topics: ["));
+        write!(f, "Topics {{ topics: [")?;
         let mut ts = self.iter();
         if let Some(t) = ts.next() {
-            try!(write!(f, "{:?}", t));
+            write!(f, "{:?}", t)?;
         }
         for t in ts {
-            try!(write!(f, ", {:?}", t));
+            write!(f, ", {:?}", t)?;
         }
         write!(f, "] }}")
     }
@@ -114,12 +114,10 @@ impl<'a> Iterator for TopicIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(name, tps)| {
-            Topic {
-                state: self.state,
-                name: &name[..],
-                tp: tps,
-            }
+        self.iter.next().map(|(name, tps)| Topic {
+            state: self.state,
+            name: &name[..],
+            tp: tps,
         })
     }
 }
@@ -150,7 +148,12 @@ impl<'a> Topic<'a> {
 
 impl<'a> fmt::Debug for Topic<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Topic {{ name: {}, partitions: {:?} }}", self.name, self.partitions())
+        write!(
+            f,
+            "Topic {{ name: {}, partitions: {:?} }}",
+            self.name,
+            self.partitions()
+        )
     }
 }
 
@@ -182,9 +185,9 @@ impl<'a> Partitions<'a> {
     /// Finds a specified partition identified by its id.
     #[inline]
     pub fn partition(&self, partition_id: i32) -> Option<Partition<'a>> {
-        self.tp.partition(partition_id).map(|p| {
-            Partition::new(self.state, p, partition_id)
-        })
+        self.tp
+            .partition(partition_id)
+            .map(|p| Partition::new(self.state, p, partition_id))
     }
 
     /// Convenience method to retrieve the identifiers of all
@@ -201,13 +204,13 @@ impl<'a> Partitions<'a> {
 
 impl<'a> fmt::Debug for Partitions<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "Partitions {{ ["));
+        write!(f, "Partitions {{ [")?;
         let mut ps = self.iter();
         if let Some(p) = ps.next() {
-            try!(write!(f, "{:?}", p));
+            write!(f, "{:?}", p)?;
         }
         for p in ps {
-            try!(write!(f, ", {:?}", p));
+            write!(f, ", {:?}", p)?;
         }
         write!(f, "] }}")
     }
@@ -251,9 +254,9 @@ impl<'a> Iterator for PartitionIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(
-            |(id, p)| Partition::new(self.state, p, id),
-        )
+        self.iter
+            .next()
+            .map(|(id, p)| Partition::new(self.state, p, id))
     }
 }
 
@@ -303,6 +306,11 @@ impl<'a> Partition<'a> {
 
 impl<'a> fmt::Debug for Partition<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Partition {{ id: {}, leader: {:?} }}", self.id(), self.leader())
+        write!(
+            f,
+            "Partition {{ id: {}, leader: {:?} }}",
+            self.id(),
+            self.leader()
+        )
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -531,7 +531,7 @@ impl KafkaClient {
     /// `KafkaClient::set_fetch_max_bytes_per_partition(..)`.
     #[inline]
     pub fn set_fetch_max_wait_time(&mut self, max_wait_time: Duration) -> Result<()> {
-        self.config.fetch_max_wait_time = try!(protocol::to_millis_i32(max_wait_time));
+        self.config.fetch_max_wait_time = protocol::to_millis_i32(max_wait_time)?;
         Ok(())
     }
 
@@ -779,7 +779,7 @@ impl KafkaClient {
     /// method call.)
     #[inline]
     pub fn load_metadata<T: AsRef<str>>(&mut self, topics: &[T]) -> Result<()> {
-        let resp = try!(self.fetch_metadata(topics));
+        let resp = self.fetch_metadata(topics)?;
         self.state.update_metadata(resp)
     }
 
@@ -869,12 +869,12 @@ impl KafkaClient {
         let now = Instant::now();
         let mut res: HashMap<String, Vec<PartitionOffset>> = HashMap::with_capacity(n_topics);
         for (host, req) in reqs {
-            let resp = try!(__send_receive::<_, protocol::OffsetResponse>(
+            let resp = __send_receive::<_, protocol::OffsetResponse>(
                 &mut self.conn_pool,
                 &host,
                 now,
                 req,
-            ));
+            )?;
             for tp in resp.topic_partitions {
                 let mut entry = res.entry(tp.topic);
                 let mut new_resp_offsets = None;
@@ -948,7 +948,7 @@ impl KafkaClient {
     ) -> Result<Vec<PartitionOffset>> {
         let topic = topic.as_ref();
 
-        let mut m = try!(self.fetch_offsets(&[topic], offset));
+        let mut m = self.fetch_offsets(&[topic], offset)?;
         let offs = m.remove(topic).unwrap_or_else(|| vec![]);
         if offs.is_empty() {
             bail!(ErrorKind::Kafka(KafkaCode::UnknownTopicOrPartition))
@@ -1123,11 +1123,7 @@ impl KafkaClient {
         J: AsRef<ProduceMessage<'a, 'b>>,
         I: IntoIterator<Item = J>,
     {
-        self.internal_produce_messages(
-            acks as i16,
-            try!(protocol::to_millis_i32(ack_timeout)),
-            messages,
-        )
+        self.internal_produce_messages(acks as i16, protocol::to_millis_i32(ack_timeout)?, messages)
     }
 
     /// Commit offset for a topic partitions on behalf of a consumer group.
@@ -1278,14 +1274,11 @@ impl KafkaClient {
             }
         }
 
-        Ok(try!(__fetch_group_offsets(
-            req,
-            &mut self.state,
-            &mut self.conn_pool,
-            &self.config
-        ))
-        .remove(topic)
-        .unwrap_or_else(Vec::new))
+        Ok(
+            __fetch_group_offsets(req, &mut self.state, &mut self.conn_pool, &self.config)?
+                .remove(topic)
+                .unwrap_or_else(Vec::new),
+        )
     }
 }
 
@@ -1355,7 +1348,7 @@ fn __get_group_coordinator<'a>(
             "get_group_coordinator: asking for coordinator of '{}' on: {:?}",
             group, conn
         );
-        let r = try!(__send_receive_conn::<_, protocol::GroupCoordinatorResponse>(conn, &req));
+        let r = __send_receive_conn::<_, protocol::GroupCoordinatorResponse>(conn, &req)?;
         let retry_code;
         match r.to_result() {
             Ok(r) => {
@@ -1392,17 +1385,13 @@ fn __commit_offsets(
         let now = Instant::now();
 
         let tps = {
-            let host = try!(__get_group_coordinator(
-                req.group, state, conn_pool, config, now
-            ));
+            let host = __get_group_coordinator(req.group, state, conn_pool, config, now)?;
             debug!(
                 "__commit_offsets: sending offset commit request '{:?}' to: {}",
                 req, host
             );
-            try!(__send_receive::<_, protocol::OffsetCommitResponse>(
-                conn_pool, host, now, &req
-            ))
-            .topic_partitions
+            __send_receive::<_, protocol::OffsetCommitResponse>(conn_pool, host, now, &req)?
+                .topic_partitions
         };
 
         let mut retry_code = None;
@@ -1460,16 +1449,12 @@ fn __fetch_group_offsets(
         let now = Instant::now();
 
         let r = {
-            let host = try!(__get_group_coordinator(
-                req.group, state, conn_pool, config, now
-            ));
+            let host = __get_group_coordinator(req.group, state, conn_pool, config, now)?;
             debug!(
                 "fetch_group_offsets: sending request {:?} to: {}",
                 req, host
             );
-            try!(__send_receive::<_, protocol::OffsetFetchResponse>(
-                conn_pool, host, now, &req
-            ))
+            __send_receive::<_, protocol::OffsetFetchResponse>(conn_pool, host, now, &req)?
         };
 
         debug!("fetch_group_offsets: received response: {:#?}", r);
@@ -1543,7 +1528,7 @@ fn __fetch_messages(
             validate_crc: config.fetch_crc_validation,
             requests: Some(&req),
         };
-        res.push(try!(__z_send_receive(conn_pool, host, now, &req, &p)));
+        res.push(__z_send_receive(conn_pool, host, now, &req, &p)?);
     }
     Ok(res)
 }
@@ -1557,17 +1542,13 @@ fn __produce_messages(
     let now = Instant::now();
     if no_acks {
         for (host, req) in reqs {
-            try!(__send_noack::<_, protocol::ProduceResponse>(
-                conn_pool, host, now, req
-            ));
+            __send_noack::<_, protocol::ProduceResponse>(conn_pool, host, now, req)?;
         }
         Ok(vec![])
     } else {
         let mut res: Vec<ProduceConfirm> = vec![];
         for (host, req) in reqs {
-            let resp = try!(__send_receive::<_, protocol::ProduceResponse>(
-                conn_pool, &host, now, req
-            ));
+            let resp = __send_receive::<_, protocol::ProduceResponse>(conn_pool, &host, now, req)?;
             for tpo in resp.get_response() {
                 res.push(tpo);
             }
@@ -1586,7 +1567,7 @@ where
     T: ToByte,
     V: FromByte,
 {
-    __send_receive_conn::<T, V>(try!(conn_pool.get_conn(host, now)), req)
+    __send_receive_conn::<T, V>(conn_pool.get_conn(host, now)?, req)
 }
 
 fn __send_receive_conn<T, V>(conn: &mut network::KafkaConnection, req: T) -> Result<V::R>
@@ -1594,7 +1575,7 @@ where
     T: ToByte,
     V: FromByte,
 {
-    try!(__send_request(conn, req));
+    __send_request(conn, req)?;
     __get_response::<V>(conn)
 }
 
@@ -1608,7 +1589,7 @@ where
     T: ToByte,
     V: FromByte,
 {
-    let mut conn = try!(conn_pool.get_conn(host, now));
+    let mut conn = conn_pool.get_conn(host, now)?;
     __send_request(&mut conn, req)
 }
 
@@ -1618,10 +1599,10 @@ fn __send_request<T: ToByte>(conn: &mut network::KafkaConnection, request: T) ->
     // ~ reserve bytes for the actual request size (we'll fill in that later)
     buffer.extend_from_slice(&[0, 0, 0, 0]);
     // ~ encode the request data
-    try!(request.encode(&mut buffer));
+    request.encode(&mut buffer)?;
     // ~ put the size of the request data into the reseved area
     let size = buffer.len() as i32 - 4;
-    try!(size.encode(&mut &mut buffer[..]));
+    size.encode(&mut &mut buffer[..])?;
 
     trace!("__send_request: Sending bytes: {:?}", &buffer);
 
@@ -1630,8 +1611,8 @@ fn __send_request<T: ToByte>(conn: &mut network::KafkaConnection, request: T) ->
 }
 
 fn __get_response<T: FromByte>(conn: &mut network::KafkaConnection) -> Result<T::R> {
-    let size = try!(__get_response_size(conn));
-    let resp = try!(conn.read_exact_alloc(size as u64));
+    let size = __get_response_size(conn)?;
+    let resp = conn.read_exact_alloc(size as u64)?;
 
     trace!("__get_response: received bytes: {:?}", &resp);
 
@@ -1661,8 +1642,8 @@ where
     R: ToByte,
     P: ResponseParser,
 {
-    let mut conn = try!(conn_pool.get_conn(host, now));
-    try!(__send_request(&mut conn, req));
+    let mut conn = conn_pool.get_conn(host, now)?;
+    __send_request(&mut conn, req)?;
     __z_get_response(&mut conn, parser)
 }
 
@@ -1670,8 +1651,8 @@ fn __z_get_response<P>(conn: &mut network::KafkaConnection, parser: &P) -> Resul
 where
     P: ResponseParser,
 {
-    let size = try!(__get_response_size(conn));
-    let resp = try!(conn.read_exact_alloc(size as u64));
+    let size = __get_response_size(conn)?;
+    let resp = conn.read_exact_alloc(size as u64)?;
 
     // {
     //     use std::fs::OpenOptions;
@@ -1690,7 +1671,7 @@ where
 
 fn __get_response_size(conn: &mut network::KafkaConnection) -> Result<i32> {
     let mut buf = [0u8; 4];
-    try!(conn.read_exact(&mut buf));
+    conn.read_exact(&mut buf)?;
     i32::decode_new(&mut Cursor::new(&buf))
 }
 

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -187,7 +187,7 @@ impl Connections {
         if let Some(conn) = self.conns.get_mut(host) {
             if now.duration_since(conn.last_checkout) >= self.config.idle_timeout {
                 debug!("Idle timeout reached: {:?}", conn.item);
-                let new_conn = try!(self.config.new_conn(self.state.next_conn_id(), host));
+                let new_conn = self.config.new_conn(self.state.next_conn_id(), host)?;
                 let _ = conn.item.shutdown();
                 conn.item = new_conn;
             }
@@ -202,7 +202,7 @@ impl Connections {
         let cid = self.state.next_conn_id();
         self.conns.insert(
             host.to_owned(),
-            Pooled::new(now, try!(self.config.new_conn(cid, host))),
+            Pooled::new(now, self.config.new_conn(cid, host)?),
         );
         Ok(&mut self.conns.get_mut(host).unwrap().item)
     }
@@ -365,7 +365,7 @@ impl KafkaConnection {
         // following call to `read_exact` or discard the vector (in
         // the error case)
         unsafe { buffer.set_len(size) };
-        try!(self.read_exact(buffer.as_mut_slice()));
+        self.read_exact(buffer.as_mut_slice())?;
         Ok(buffer)
     }
 
@@ -381,8 +381,8 @@ impl KafkaConnection {
         host: &str,
         rw_timeout: Option<Duration>,
     ) -> Result<KafkaConnection> {
-        try!(stream.set_read_timeout(rw_timeout));
-        try!(stream.set_write_timeout(rw_timeout));
+        stream.set_read_timeout(rw_timeout)?;
+        stream.set_write_timeout(rw_timeout)?;
         Ok(KafkaConnection {
             id,
             host: host.to_owned(),
@@ -392,7 +392,7 @@ impl KafkaConnection {
 
     #[cfg(not(feature = "security"))]
     fn new(id: u32, host: &str, rw_timeout: Option<Duration>) -> Result<KafkaConnection> {
-        KafkaConnection::from_stream(try!(TcpStream::connect(host)), id, host, rw_timeout)
+        KafkaConnection::from_stream(TcpStream::connect(host)?, id, host, rw_timeout)
     }
 
     #[cfg(feature = "security")]
@@ -402,7 +402,7 @@ impl KafkaConnection {
         rw_timeout: Option<Duration>,
         security: Option<(SslConnector, bool)>,
     ) -> Result<KafkaConnection> {
-        let stream = try!(TcpStream::connect(host));
+        let stream = TcpStream::connect(host)?;
         let stream = match security {
             Some((connector, verify_hostname)) => {
                 if !verify_hostname {
@@ -419,7 +419,7 @@ impl KafkaConnection {
                     None => host,
                     Some(i) => &host[..i],
                 };
-                let connection = try!(connector.connect(domain, stream));
+                let connection = connector.connect(domain, stream)?;
                 KafkaStream::Ssl(connection)
             }
             None => KafkaStream::Plain(stream),

--- a/src/compression/gzip.rs
+++ b/src/compression/gzip.rs
@@ -1,21 +1,21 @@
 use std::io::{Read, Write};
 
-use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 
 use error::Result;
 
 pub fn compress(src: &[u8]) -> Result<Vec<u8>> {
     let mut e = GzEncoder::new(Vec::new(), Compression::Default);
 
-    try!(e.write(src));
-    let compressed_bytes = try!(e.finish());
+    e.write(src)?;
+    let compressed_bytes = e.finish()?;
     Ok((compressed_bytes))
 }
 
 pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>> {
-    let mut d = try!(GzDecoder::new(src));
+    let mut d = GzDecoder::new(src)?;
 
     let mut buffer: Vec<u8> = Vec::new();
     match d.read_to_end(&mut buffer) {
@@ -29,29 +29,7 @@ fn test_uncompress() {
     use std::io::Cursor;
     // The vector should uncompress to "test"
     let msg: Vec<u8> = vec![
-        31,
-        139,
-        8,
-        0,
-        192,
-        248,
-        79,
-        85,
-        2,
-        255,
-        43,
-        73,
-        45,
-        46,
-        1,
-        0,
-        12,
-        126,
-        127,
-        216,
-        4,
-        0,
-        0,
+        31, 139, 8, 0, 192, 248, 79, 85, 2, 255, 43, 73, 45, 46, 1, 0, 12, 126, 127, 216, 4, 0, 0,
         0,
     ];
     let uncomp_msg = String::from_utf8(uncompress(Cursor::new(msg)).unwrap()).unwrap();
@@ -63,20 +41,7 @@ fn test_uncompress() {
 fn test_uncompress_panic() {
     use std::io::Cursor;
     let msg: Vec<u8> = vec![
-        12,
-        42,
-        84,
-        104,
-        105,
-        115,
-        32,
-        105,
-        115,
-        32,
-        116,
-        101,
-        115,
-        116,
+        12, 42, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116,
     ];
     let uncomp_msg = String::from_utf8(uncompress(Cursor::new(msg)).unwrap()).unwrap();
     assert_eq!(&uncomp_msg[..], "This is test");

--- a/src/compression/snappy.rs
+++ b/src/compression/snappy.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read};
 use byteorder::{BigEndian, ByteOrder};
 use snap;
 
-use error::{Result, Error, ErrorKind};
+use error::{Error, ErrorKind, Result};
 
 pub fn compress(src: &[u8]) -> Result<Vec<u8>> {
     let mut buf = vec![0; snap::max_compress_len(src.len())];
@@ -25,7 +25,7 @@ fn uncompress_to(src: &[u8], dst: &mut Vec<u8>) -> Result<()> {
                 dst.resize(off + min_len, 0);
                 let uncompressed_len = {
                     let buf = &mut dst.as_mut_slice()[off..off + min_len];
-                    try!(snap::Decoder::new().decompress(src, buf))
+                    snap::Decoder::new().decompress(src, buf)?
                 };
                 dst.truncate(off + uncompressed_len);
             }
@@ -45,11 +45,12 @@ macro_rules! next_i32 {
         if $slice.len() < 4 {
             bail!(ErrorKind::UnexpectedEOF);
         }
-        { let n = BigEndian::read_i32($slice);
-          $slice = &$slice[4..];
-          n
+        {
+            let n = BigEndian::read_i32($slice);
+            $slice = &$slice[4..];
+            n
         }
-    }}
+    }};
 }
 
 /// Validates the expected header at the beginning of the
@@ -81,23 +82,7 @@ fn validate_stream(mut stream: &[u8]) -> Result<&[u8]> {
 #[test]
 fn test_validate_stream() {
     let header = [
-        0x82,
-        0x53,
-        0x4e,
-        0x41,
-        0x50,
-        0x50,
-        0x59,
-        0x00,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        1,
-        0x56,
+        0x82, 0x53, 0x4e, 0x41, 0x50, 0x50, 0x59, 0x00, 0, 0, 0, 1, 0, 0, 0, 1, 0x56,
     ];
     // ~ this must not result in a panic
     let rest = validate_stream(&header).unwrap();
@@ -122,7 +107,7 @@ pub struct SnappyReader<'a> {
 
 impl<'a> SnappyReader<'a> {
     pub fn new(mut stream: &[u8]) -> Result<SnappyReader> {
-        stream = try!(validate_stream(stream));
+        stream = validate_stream(stream)?;
         Ok(SnappyReader {
             compressed_data: stream,
             uncompressed_pos: 0,
@@ -133,7 +118,7 @@ impl<'a> SnappyReader<'a> {
     fn _read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if self.uncompressed_pos < self.uncompressed_chunk.len() {
             self.read_uncompressed(buf)
-        } else if try!(self.next_chunk()) {
+        } else if self.next_chunk()? {
             self.read_uncompressed(buf)
         } else {
             Ok(0)
@@ -141,7 +126,7 @@ impl<'a> SnappyReader<'a> {
     }
 
     fn read_uncompressed(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let n = try!((&self.uncompressed_chunk[self.uncompressed_pos..]).read(buf));
+        let n = (&self.uncompressed_chunk[self.uncompressed_pos..]).read(buf)?;
         self.uncompressed_pos += n;
         Ok(n)
     }
@@ -153,14 +138,19 @@ impl<'a> SnappyReader<'a> {
         self.uncompressed_pos = 0;
         let chunk_size = next_i32!(self.compressed_data);
         if chunk_size <= 0 {
-            bail!(ErrorKind::InvalidSnappy(snap::Error::UnsupportedChunkLength {
-                len: chunk_size as u64,
-                header: false,
-            }));
+            bail!(ErrorKind::InvalidSnappy(
+                snap::Error::UnsupportedChunkLength {
+                    len: chunk_size as u64,
+                    header: false,
+                }
+            ));
         }
         let chunk_size = chunk_size as usize;
         self.uncompressed_chunk.clear();
-        try!(uncompress_to(&self.compressed_data[..chunk_size], &mut self.uncompressed_chunk));
+        uncompress_to(
+            &self.compressed_data[..chunk_size],
+            &mut self.uncompressed_chunk,
+        )?;
         self.compressed_data = &self.compressed_data[chunk_size..];
         Ok(true)
     }
@@ -177,13 +167,15 @@ impl<'a> SnappyReader<'a> {
         while !self.compressed_data.is_empty() {
             let chunk_size = next_i32!(self.compressed_data);
             if chunk_size <= 0 {
-                bail!(ErrorKind::InvalidSnappy(snap::Error::UnsupportedChunkLength {
-                    len: chunk_size as u64,
-                    header: false,
-                }));
+                bail!(ErrorKind::InvalidSnappy(
+                    snap::Error::UnsupportedChunkLength {
+                        len: chunk_size as u64,
+                        header: false,
+                    }
+                ));
             }
             let (c1, c2) = self.compressed_data.split_at(chunk_size as usize);
-            try!(uncompress_to(c1, buf));
+            uncompress_to(c1, buf)?;
             self.compressed_data = c2;
         }
         Ok(buf.len() - init_len)
@@ -199,7 +191,7 @@ macro_rules! to_io_error {
             // ~ wrapp our other errors
             Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.description())),
         }
-    }
+    };
 }
 
 impl<'a> Read for SnappyReader<'a> {
@@ -216,11 +208,11 @@ impl<'a> Read for SnappyReader<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::str;
     use std::io::Read;
+    use std::str;
 
-    use error::{Error, ErrorKind, Result};
     use super::{compress, uncompress_to, SnappyReader};
+    use error::{Error, ErrorKind, Result};
 
     fn uncompress(src: &[u8]) -> Result<Vec<u8>> {
         let mut v = Vec::new();
@@ -235,20 +227,7 @@ mod tests {
         let msg = "This is test".as_bytes();
         let compressed = compress(msg).unwrap();
         let expected = &[
-            12,
-            44,
-            84,
-            104,
-            105,
-            115,
-            32,
-            105,
-            115,
-            32,
-            116,
-            101,
-            115,
-            116,
+            12, 44, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116,
         ];
         assert_eq!(&compressed, expected);
     }
@@ -257,20 +236,7 @@ mod tests {
     fn test_uncompress() {
         // The vector should uncompress to "This is test"
         let compressed = &[
-            12,
-            44,
-            84,
-            104,
-            105,
-            115,
-            32,
-            105,
-            115,
-            32,
-            116,
-            101,
-            115,
-            116,
+            12, 44, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116,
         ];
         let uncompressed = String::from_utf8(uncompress(compressed).unwrap()).unwrap();
         assert_eq!(&uncompressed, "This is test");
@@ -280,28 +246,17 @@ mod tests {
     fn test_uncompress_invalid_input() {
         // The vector is an invalid snappy message (second byte modified on purpose)
         let compressed = &[
-            12,
-            42,
-            84,
-            104,
-            105,
-            115,
-            32,
-            105,
-            115,
-            32,
-            116,
-            101,
-            115,
-            116,
+            12, 42, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116,
         ];
         let uncompressed = uncompress(compressed);
         assert!(uncompressed.is_err());
-        assert!(if let Some(Error(ErrorKind::InvalidSnappy(_), _)) = uncompressed.err() {
-            true
-        } else {
-            false
-        });
+        assert!(
+            if let Some(Error(ErrorKind::InvalidSnappy(_), _)) = uncompressed.err() {
+                true
+            } else {
+                false
+            }
+        );
     }
 
     static ORIGINAL: &'static str = include_str!("../../test-data/fetch1.txt");

--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use client::{self, KafkaClient, FetchOffset, GroupOffsetStorage};
+use client::{self, FetchOffset, GroupOffsetStorage, KafkaClient};
 use error::{ErrorKind, Result};
 
-use super::{Consumer, DEFAULT_FALLBACK_OFFSET, DEFAULT_RETRY_MAX_BYTES_LIMIT};
+use super::assignment;
 use super::config::Config;
 use super::state::State;
-use super::assignment;
+use super::{Consumer, DEFAULT_FALLBACK_OFFSET, DEFAULT_RETRY_MAX_BYTES_LIMIT};
 
 #[cfg(feature = "security")]
 use client::SecurityConfig;
@@ -228,10 +228,13 @@ impl Builder {
         // ~ create the client if necessary
         let (mut client, need_metadata) = match self.client {
             Some(client) => (client, false),
-            None => (Self::new_kafka_client(self.hosts, self.security_config), true),
+            None => (
+                Self::new_kafka_client(self.hosts, self.security_config),
+                true,
+            ),
         };
         // ~ apply configuration settings
-        try!(client.set_fetch_max_wait_time(self.fetch_max_wait_time));
+        client.set_fetch_max_wait_time(self.fetch_max_wait_time)?;
         client.set_fetch_min_bytes(self.fetch_min_bytes);
         client.set_fetch_max_bytes_per_partition(self.fetch_max_bytes_per_partition);
         client.set_group_offset_storage(self.group_offset_storage);
@@ -241,7 +244,7 @@ impl Builder {
         }
         // ~ load metadata if necessary
         if need_metadata {
-            try!(client.load_metadata_all());
+            client.load_metadata_all()?;
         }
         // ~ load consumer state
         let config = Config {
@@ -249,8 +252,11 @@ impl Builder {
             fallback_offset: self.fallback_offset,
             retry_max_bytes_limit: self.retry_max_bytes_limit,
         };
-        let state = try!(State::new(&mut client, &config, assignment::from_map(self.assignments)));
-        debug!("initialized: Consumer {{ config: {:?}, state: {:?} }}", config, state);
+        let state = State::new(&mut client, &config, assignment::from_map(self.assignments))?;
+        debug!(
+            "initialized: Consumer {{ config: {:?}, state: {:?} }}",
+            config, state
+        );
         Ok(Consumer {
             client: client,
             state: state,

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -64,20 +64,20 @@
 use std::collections::hash_map::{Entry, HashMap};
 use std::slice;
 
-use client::{KafkaClient, FetchPartition, CommitOffset};
-use error::{ErrorKind, KafkaCode, Result};
 use client::fetch;
+use client::{CommitOffset, FetchPartition, KafkaClient};
+use error::{ErrorKind, KafkaCode, Result};
 
 // public re-exports
+pub use self::builder::Builder;
 pub use client::fetch::Message;
 pub use client::FetchOffset;
 pub use client::GroupOffsetStorage;
-pub use self::builder::Builder;
 
 mod assignment;
+mod builder;
 mod config;
 mod state;
-mod builder;
 
 /// The default value for `Builder::with_retry_max_bytes_limit`.
 pub const DEFAULT_RETRY_MAX_BYTES_LIMIT: i32 = 0;
@@ -135,9 +135,11 @@ impl Consumer {
         let mut h: HashMap<String, Vec<i32>> =
             HashMap::with_capacity(self.state.assignments.as_slice().len());
         // ~ expand subscriptions to (topic-name, partition id)
-        let tps = self.state.fetch_offsets.keys().map(|tp| {
-            (self.state.topic_name(tp.topic_ref), tp.partition)
-        });
+        let tps = self
+            .state
+            .fetch_offsets
+            .keys()
+            .map(|tp| (self.state.topic_name(tp.topic_ref), tp.partition));
         // ~ group by topic-name
         for tp in tps {
             // ~ allocate topic-name only once per topic
@@ -153,7 +155,7 @@ impl Consumer {
     /// Polls for the next available message data.
     pub fn poll(&mut self) -> Result<MessageSets> {
         let (n, resps) = self.fetch_messages();
-        self.process_fetch_responses(n, try!(resps))
+        self.process_fetch_responses(n, resps?)
     }
 
     /// Determines whether this consumer is set up to consume only a
@@ -178,15 +180,16 @@ impl Consumer {
                 let s = match self.state.fetch_offsets.get(&tp) {
                     Some(fstate) => fstate,
                     None => {
-                        return (1, Err(ErrorKind::Kafka(KafkaCode::UnknownTopicOrPartition).into()))
+                        return (
+                            1,
+                            Err(ErrorKind::Kafka(KafkaCode::UnknownTopicOrPartition).into()),
+                        )
                     }
                 };
                 let topic = self.state.topic_name(tp.topic_ref);
                 debug!(
                     "fetching retry messages: (fetch-offset: {{\"{}:{}\": {:?}}})",
-                    topic,
-                    tp.partition,
-                    s
+                    topic, tp.partition, s
                 );
                 (
                     1,
@@ -199,12 +202,18 @@ impl Consumer {
             None => {
                 let client = &mut self.client;
                 let state = &self.state;
-                debug!("fetching messages: (fetch-offsets: {:?})", state.fetch_offsets_debug());
+                debug!(
+                    "fetching messages: (fetch-offsets: {:?})",
+                    state.fetch_offsets_debug()
+                );
                 let reqs = state.fetch_offsets.iter().map(|(tp, s)| {
                     let topic = state.topic_name(tp.topic_ref);
                     FetchPartition::new(topic, tp.partition, s.offset).with_max_bytes(s.max_bytes)
                 });
-                (state.fetch_offsets.len() as u32, client.fetch_messages(reqs))
+                (
+                    state.fetch_offsets.len() as u32,
+                    client.fetch_messages(reqs),
+                )
             }
         }
     }
@@ -226,9 +235,11 @@ impl Consumer {
 
         for resp in &resps {
             for t in resp.topics() {
-                let topic_ref = self.state.assignments.topic_ref(t.topic()).expect(
-                    "unknown topic in response",
-                );
+                let topic_ref = self
+                    .state
+                    .assignments
+                    .topic_ref(t.topic())
+                    .expect("unknown topic in response");
 
                 for p in t.partitions() {
                     let tp = state::TopicPartition {
@@ -248,9 +259,11 @@ impl Consumer {
                         &Ok(ref data) => data,
                     };
 
-                    let mut fetch_state = self.state.fetch_offsets.get_mut(&tp).expect(
-                        "non-requested partition",
-                    );
+                    let mut fetch_state = self
+                        .state
+                        .fetch_offsets
+                        .get_mut(&tp)
+                        .expect("non-requested partition");
                     // ~ book keeping
                     if let Some(last_msg) = data.messages().last() {
                         fetch_state.offset = last_msg.offset + 1;
@@ -273,7 +286,7 @@ impl Consumer {
                     } else {
                         debug!(
                             "no data received for {}:{} (max_bytes: {} / fetch_offset: {} / \
-                                highwatermark_offset: {})",
+                             highwatermark_offset: {})",
                             t.topic(),
                             tp.partition,
                             fetch_state.max_bytes,
@@ -396,7 +409,11 @@ impl Consumer {
     /// message of the given set as consumed.
     pub fn consume_messageset<'a>(&mut self, msgs: MessageSet<'a>) -> Result<()> {
         if !msgs.messages.is_empty() {
-            self.consume_message(msgs.topic, msgs.partition, msgs.messages.last().unwrap().offset)
+            self.consume_message(
+                msgs.topic,
+                msgs.partition,
+                msgs.messages.last().unwrap().offset,
+            )
         } else {
             Ok(())
         }
@@ -418,25 +435,23 @@ impl Consumer {
             self.state.consumed_offsets_debug()
         );
         let (client, state) = (&mut self.client, &mut self.state);
-        try!(
-            client.commit_offsets(
-                &self.config.group,
-                state
-                    .consumed_offsets
-                    .iter()
-                    .filter(|&(_, o)| o.dirty)
-                    .map(|(tp, o)| {
-                        let topic = state.topic_name(tp.topic_ref);
+        client.commit_offsets(
+            &self.config.group,
+            state
+                .consumed_offsets
+                .iter()
+                .filter(|&(_, o)| o.dirty)
+                .map(|(tp, o)| {
+                    let topic = state.topic_name(tp.topic_ref);
 
-                        // Note that the offset that is committed should be the
-                        // offset of the next message a consumer should read, so
-                        // add one to the consumed message's offset.
-                        //
-                        // https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html
-                        CommitOffset::new(topic, tp.partition, o.offset + 1)
-                    }),
-            )
-        );
+                    // Note that the offset that is committed should be the
+                    // offset of the next message a consumer should read, so
+                    // add one to the consumed message's offset.
+                    //
+                    // https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html
+                    CommitOffset::new(topic, tp.partition, o.offset + 1)
+                }),
+        )?;
         for (_, co) in &mut state.consumed_offsets {
             if co.dirty {
                 co.dirty = false;
@@ -473,12 +488,12 @@ impl MessageSets {
     pub fn iter(&self) -> MessageSetsIter {
         let mut responses = self.responses.iter();
         let mut topics = responses.next().map(|r| r.topics().iter());
-        let (curr_topic, partitions) = topics.as_mut().and_then(|t| t.next()).map_or(
-            (None, None),
-            |t| {
+        let (curr_topic, partitions) = topics
+            .as_mut()
+            .and_then(|t| t.next())
+            .map_or((None, None), |t| {
                 (Some(t.topic()), Some(t.partitions().iter()))
-            },
-        );
+            });
         MessageSetsIter {
             responses: responses,
             topics: topics,

--- a/src/protocol/metadata.rs
+++ b/src/protocol/metadata.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
+use codecs::{AsStrings, FromByte, ToByte};
 use error::Result;
-use codecs::{AsStrings, ToByte, FromByte};
 
 use super::{HeaderRequest, HeaderResponse};
 use super::{API_KEY_METADATA, API_VERSION};
@@ -23,7 +23,9 @@ impl<'a, T: AsRef<str>> MetadataRequest<'a, T> {
 
 impl<'a, T: AsRef<str> + 'a> ToByte for MetadataRequest<'a, T> {
     fn encode<W: Write>(&self, buffer: &mut W) -> Result<()> {
-        try_multi!(self.header.encode(buffer), AsStrings(self.topics).encode(buffer))
+        self.header.encode(buffer)?;
+        AsStrings(self.topics).encode(buffer)?;
+        Ok(())
     }
 }
 
@@ -64,11 +66,10 @@ impl FromByte for MetadataResponse {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.header.decode(buffer),
-            self.brokers.decode(buffer),
-            self.topics.decode(buffer)
-        )
+        self.header.decode(buffer)?;
+        self.brokers.decode(buffer)?;
+        self.topics.decode(buffer)?;
+        Ok(())
     }
 }
 
@@ -77,7 +78,10 @@ impl FromByte for BrokerMetadata {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(self.node_id.decode(buffer), self.host.decode(buffer), self.port.decode(buffer))
+        self.node_id.decode(buffer)?;
+        self.host.decode(buffer)?;
+        self.port.decode(buffer)?;
+        Ok(())
     }
 }
 
@@ -86,11 +90,10 @@ impl FromByte for TopicMetadata {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.error.decode(buffer),
-            self.topic.decode(buffer),
-            self.partitions.decode(buffer)
-        )
+        self.error.decode(buffer)?;
+        self.topic.decode(buffer)?;
+        self.partitions.decode(buffer)?;
+        Ok(())
     }
 }
 
@@ -99,12 +102,11 @@ impl FromByte for PartitionMetadata {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.error.decode(buffer),
-            self.id.decode(buffer),
-            self.leader.decode(buffer),
-            self.replicas.decode(buffer),
-            self.isr.decode(buffer)
-        )
+        self.error.decode(buffer)?;
+        self.id.decode(buffer)?;
+        self.leader.decode(buffer)?;
+        self.replicas.decode(buffer)?;
+        self.isr.decode(buffer)?;
+        Ok(())
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,35 +2,28 @@ use std::io::{Read, Write};
 use std::mem;
 use std::time::Duration;
 
-use codecs::{ToByte, FromByte};
+use codecs::{FromByte, ToByte};
 use crc::crc32;
 use error::{Error, ErrorKind, KafkaCode, Result};
 
-/// Macro to return Result<()> from multiple statements
-macro_rules! try_multi {
-    ($($expr:expr),*) => ({
-        $(try!($expr);)*;
-        Ok(())
-    })
-}
-
-pub mod produce;
-pub mod offset;
-pub mod metadata;
 pub mod consumer;
+pub mod metadata;
+pub mod offset;
+pub mod produce;
 
-mod zreader;
 pub mod fetch;
+mod zreader;
 
 // ~ convenient re-exports for request/response types defined in the
 // submodules
+pub use self::consumer::{
+    GroupCoordinatorRequest, GroupCoordinatorResponse, OffsetCommitRequest, OffsetCommitResponse,
+    OffsetCommitVersion, OffsetFetchRequest, OffsetFetchResponse, OffsetFetchVersion,
+};
 pub use self::fetch::FetchRequest;
-pub use self::produce::{ProduceRequest, ProduceResponse};
-pub use self::offset::{OffsetRequest, OffsetResponse};
 pub use self::metadata::{MetadataRequest, MetadataResponse};
-pub use self::consumer::{GroupCoordinatorRequest, GroupCoordinatorResponse, OffsetFetchVersion,
-                         OffsetFetchRequest, OffsetFetchResponse, OffsetCommitVersion,
-                         OffsetCommitRequest, OffsetCommitResponse};
+pub use self::offset::{OffsetRequest, OffsetResponse};
+pub use self::produce::{ProduceRequest, ProduceResponse};
 
 // --------------------------------------------------------------------
 
@@ -75,8 +68,12 @@ fn test_kafka_code_from_protocol() {
 
     macro_rules! assert_kafka_code {
         ($kcode:path, $n:expr) => {
-            assert!(if let Some($kcode) = KafkaCode::from_protocol($n) { true } else { false })
-        }
+            assert!(if let Some($kcode) = KafkaCode::from_protocol($n) {
+                true
+            } else {
+                false
+            })
+        };
     };
 
     assert!(if let None = KafkaCode::from_protocol(0) {
@@ -84,9 +81,18 @@ fn test_kafka_code_from_protocol() {
     } else {
         false
     });
-    assert_kafka_code!(KafkaCode::OffsetOutOfRange, KafkaCode::OffsetOutOfRange as i16);
-    assert_kafka_code!(KafkaCode::IllegalGeneration, KafkaCode::IllegalGeneration as i16);
-    assert_kafka_code!(KafkaCode::UnsupportedVersion, KafkaCode::UnsupportedVersion as i16);
+    assert_kafka_code!(
+        KafkaCode::OffsetOutOfRange,
+        KafkaCode::OffsetOutOfRange as i16
+    );
+    assert_kafka_code!(
+        KafkaCode::IllegalGeneration,
+        KafkaCode::IllegalGeneration as i16
+    );
+    assert_kafka_code!(
+        KafkaCode::UnsupportedVersion,
+        KafkaCode::UnsupportedVersion as i16
+    );
     assert_kafka_code!(KafkaCode::Unknown, KafkaCode::Unknown as i16);
     // ~ test some un mapped non-zero codes; should all map to "unknown"
     assert_kafka_code!(KafkaCode::Unknown, i16::MAX);
@@ -130,12 +136,11 @@ impl<'a> HeaderRequest<'a> {
 
 impl<'a> ToByte for HeaderRequest<'a> {
     fn encode<W: Write>(&self, buffer: &mut W) -> Result<()> {
-        try_multi!(
-            self.api_key.encode(buffer),
-            self.api_version.encode(buffer),
-            self.correlation_id.encode(buffer),
-            self.client_id.encode(buffer)
-        )
+        self.api_key.encode(buffer)?;
+        self.api_version.encode(buffer)?;
+        self.correlation_id.encode(buffer)?;
+        self.client_id.encode(buffer)?;
+        Ok(())
     }
 }
 
@@ -167,10 +172,10 @@ pub fn to_crc(data: &[u8]) -> u32 {
 /// i32 as often required in the kafka protocol.
 pub fn to_millis_i32(d: Duration) -> Result<i32> {
     use std::i32;
-    let m = d.as_secs().saturating_mul(1_000).saturating_add(
-        (d.subsec_nanos() / 1_000_000) as
-            u64,
-    );
+    let m = d
+        .as_secs()
+        .saturating_mul(1_000)
+        .saturating_add((d.subsec_nanos() / 1_000_000) as u64);
     if m > i32::MAX as u64 {
         bail!(ErrorKind::InvalidDuration)
     } else {

--- a/src/protocol/offset.rs
+++ b/src/protocol/offset.rs
@@ -1,12 +1,11 @@
 use std::io::{Read, Write};
 
-use std;
-use codecs::{ToByte, FromByte};
-use error::{Result, KafkaCode};
-use utils::PartitionOffset;
 use super::{HeaderRequest, HeaderResponse};
 use super::{API_KEY_OFFSET, API_VERSION};
-
+use codecs::{FromByte, ToByte};
+use error::{KafkaCode, Result};
+use std;
+use utils::PartitionOffset;
 
 #[derive(Debug)]
 pub struct OffsetRequest<'a> {
@@ -59,9 +58,8 @@ impl<'a> TopicPartitionOffsetRequest<'a> {
     }
 
     pub fn add(&mut self, partition: i32, time: i64) {
-        self.partitions.push(
-            PartitionOffsetRequest::new(partition, time),
-        );
+        self.partitions
+            .push(PartitionOffsetRequest::new(partition, time));
     }
 }
 
@@ -77,27 +75,27 @@ impl PartitionOffsetRequest {
 
 impl<'a> ToByte for OffsetRequest<'a> {
     fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.header.encode(buffer),
-            self.replica.encode(buffer),
-            self.topic_partitions.encode(buffer)
-        )
+        self.header.encode(buffer)?;
+        self.replica.encode(buffer)?;
+        self.topic_partitions.encode(buffer)?;
+        Ok(())
     }
 }
 
 impl<'a> ToByte for TopicPartitionOffsetRequest<'a> {
     fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
-        try_multi!(self.topic.encode(buffer), self.partitions.encode(buffer))
+        self.topic.encode(buffer)?;
+        self.partitions.encode(buffer)?;
+        Ok(())
     }
 }
 
 impl ToByte for PartitionOffsetRequest {
     fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.partition.encode(buffer),
-            self.time.encode(buffer),
-            self.max_offsets.encode(buffer)
-        )
+        self.partition.encode(buffer)?;
+        self.time.encode(buffer)?;
+        self.max_offsets.encode(buffer)?;
+        Ok(())
     }
 }
 
@@ -146,7 +144,9 @@ impl FromByte for OffsetResponse {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(self.header.decode(buffer), self.topic_partitions.decode(buffer))
+        self.header.decode(buffer)?;
+        self.topic_partitions.decode(buffer)?;
+        Ok(())
     }
 }
 
@@ -155,7 +155,9 @@ impl FromByte for TopicPartitionOffsetResponse {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(self.topic.decode(buffer), self.partitions.decode(buffer))
+        self.topic.decode(buffer)?;
+        self.partitions.decode(buffer)?;
+        Ok(())
     }
 }
 
@@ -164,10 +166,9 @@ impl FromByte for PartitionOffsetResponse {
 
     #[allow(unused_must_use)]
     fn decode<T: Read>(&mut self, buffer: &mut T) -> Result<()> {
-        try_multi!(
-            self.partition.decode(buffer),
-            self.error.decode(buffer),
-            self.offset.decode(buffer)
-        )
+        self.partition.decode(buffer)?;
+        self.error.decode(buffer)?;
+        self.offset.decode(buffer)?;
+        Ok(())
     }
 }

--- a/src/protocol/zreader.rs
+++ b/src/protocol/zreader.rs
@@ -11,7 +11,9 @@ pub struct ZReader<'a> {
 
 // ~ a helper macro to hide away the used byte order
 macro_rules! dec {
-    ($method:ident, $src:expr) => { BigEndian::$method($src) }
+    ($method:ident, $src:expr) => {
+        BigEndian::$method($src)
+    };
 }
 
 impl<'a> ZReader<'a> {
@@ -64,12 +66,12 @@ impl<'a> ZReader<'a> {
     /// Reads a string as defined by the Kafka Protocol. The 'null'
     /// string is delivered as the empty string.
     pub fn read_str<'b>(&'b mut self) -> Result<&'a str> {
-        let len = try!(self.read_i16());
+        let len = self.read_i16()?;
         if len <= 0 {
             Ok(EMPTY_STR)
         } else {
             // alternatively: str::from_utf8_unchecked(..)
-            match str::from_utf8(try!(self.read(len as usize))) {
+            match str::from_utf8(self.read(len as usize)?) {
                 Ok(s) => Ok(s),
                 Err(_) => bail!(ErrorKind::StringDecodeError),
             }
@@ -79,7 +81,7 @@ impl<'a> ZReader<'a> {
     /// Reads 'bytes' as defined by the Kafka Protocol. The 'null'
     /// bytes are delivered as an empty slice.
     pub fn read_bytes<'b>(&'b mut self) -> Result<&'a [u8]> {
-        let len = try!(self.read_i32());
+        let len = self.read_i32()?;
         if len <= 0 {
             Ok(&self.data[0..0])
         } else {
@@ -91,7 +93,7 @@ impl<'a> ZReader<'a> {
     /// Protocol. The size of 'null' array will be returned as the
     /// size an array of an empty array.
     pub fn read_array_len(&mut self) -> Result<usize> {
-        let len = try!(self.read_i32());
+        let len = self.read_i32()?;
         Ok(if len < 0 { 0 } else { len as usize })
     }
 }
@@ -185,22 +187,7 @@ fn test_read_i64() {
 #[test]
 fn test_read_str() {
     let data = &[
-        0u8,
-        5,
-        b'h',
-        b'e',
-        b'l',
-        b'l',
-        b'o',
-        0u8,
-        7,
-        b',',
-        b' ',
-        b'w',
-        b'o',
-        b'r',
-        b'l',
-        b'd',
+        0u8, 5, b'h', b'e', b'l', b'l', b'o', 0u8, 7, b',', b' ', b'w', b'o', b'r', b'l', b'd',
         255, /* a "null" string */
         28,
     ]; // some byte


### PR DESCRIPTION
This is one of those PullRequests that nobody enjoys reviewing, sorry.

I'm farely new to Rust. I've been using it for so little that I don't 
know when `try!` was marked as deprecated. Since it's a construct a 
little bit foreign, I was having a hard time navigating the code with 
all its mentions. So I went ahead and removed it from the project.

My editor formats the code on save according to `cargo fmt`, so 
unfortunately, this changeset includes a bunch of additional formatting 
changes. :pensive: