### PR TITLE
Added Kafka 3.1.0 to integration tests and changed misc error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,11 @@ tracing = "0.1.31"
 
 [dev-dependencies]
 getopts = "0.2.21"
-env_logger = "0.9.0"
+tracing-subscriber = "0.3"
 time = "0.3.7"
 rand = "0.8.5"
 lazy_static = "1.4.0"
 anyhow = "1.0.55"
-log = "0.4.16"
 
 [features]
 default = ["snappy", "gzip", "security"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ documentation](http://doc.crates.io/manifest.html#the-features-section).
 
 ## Supported Kafka version
 
-`kafka-rust` is tested for compatibility with Kafka 0.8.2 and newer. However,
+`kafka-rust` is tested for compatibility with a select few Kafka versions from 0.8.2 to 3.1.0. However,
 not all features from Kafka 0.9 and newer are supported yet.
 
 ## Examples

--- a/examples/console-producer.rs
+++ b/examples/console-producer.rs
@@ -1,13 +1,12 @@
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Result};
 use std::fs::File;
-use std::io::{self, stderr, stdin, BufRead, BufReader, Write};
+use std::io::{stderr, stdin, BufRead, BufReader, Write};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::time::Duration;
 use std::{env, process};
 
 use anyhow::anyhow;
-use kafka::Error;
 
 use kafka::client::{
     Compression, KafkaClient, RequiredAcks, DEFAULT_CONNECTION_IDLE_TIMEOUT_MILLIS,
@@ -21,7 +20,7 @@ use kafka::producer::{AsBytes, Producer, Record, DEFAULT_ACK_TIMEOUT_MILLIS};
 /// Alternatively, messages can be read from an input file and sent do
 /// kafka in batches (the typical use-case).
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let cfg = match Config::from_cmdline() {
         Ok(cfg) => cfg,
@@ -201,13 +200,20 @@ impl Config {
         opts.optopt("", "batch-size", "Send N message in one batch.", "N");
         opts.optopt("", "idle-timeout", "Specify timeout for idle connections", "MILLIS");
 
+        macro_rules! on_error {
+            ($name:expr) => {{
+                let brief = format!("{} [options]", args[0]);
+                println!("{}", opts.usage(&brief));
+                bail!($name);
+            }};
+        }
+
         let m = match opts.parse(&args[1..]) {
             Ok(m) => m,
-            Err(e) => return Err(anyhow!("Error {:?}", e)),
+            Err(e) => on_error!(format!("Error {:?}", e)),
         };
         if m.opt_present("help") {
-            let brief = format!("{} [options]", args[0]);
-            return Err(anyhow!("opts usage: {:?}", opts.usage(&brief)));
+            on_error!("help")
         }
         Ok(Config {
             brokers: m

--- a/examples/example-consume.rs
+++ b/examples/example-consume.rs
@@ -6,7 +6,7 @@ use kafka::error::Error as KafkaError;
 /// that messages must be marked and commited as consumed to ensure
 /// only once delivery.
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let broker = "localhost:9092".to_owned();
     let topic = "my-topic".to_owned();
@@ -22,7 +22,7 @@ fn consume_messages(group: String, topic: String, brokers: Vec<String>) -> Resul
         .with_topic(topic)
         .with_group(group)
         .with_fallback_offset(FetchOffset::Earliest)
-        .with_offset_storage(GroupOffsetStorage::Kafka)
+        .with_offset_storage(Some(GroupOffsetStorage::Kafka))
         .create()?;
 
     loop {

--- a/examples/example-fetch.rs
+++ b/examples/example-fetch.rs
@@ -3,7 +3,7 @@ use kafka::client::{FetchPartition, KafkaClient};
 /// This program demonstrates the low level api for fetching messages.
 /// Please look at examles/consume.rs for an easier to use API.
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let broker = "localhost:9092";
     let topic = "my-topic";

--- a/examples/example-produce.rs
+++ b/examples/example-produce.rs
@@ -7,7 +7,7 @@ use kafka::producer::{Producer, Record, RequiredAcks};
 /// `Producer`.  This is a convenient higher-level client that will
 /// fit most use cases.
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let broker = "localhost:9092";
     let topic = "my-topic";

--- a/examples/example-ssl.rs
+++ b/examples/example-ssl.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate log;
-
 fn main() {
     example::main();
 }
@@ -9,6 +6,7 @@ fn main() {
 mod example {
     use kafka;
     use openssl;
+    use tracing::info;
 
     use std::env;
     use std::process;
@@ -18,7 +16,7 @@ mod example {
     use self::openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 
     pub fn main() {
-        env_logger::init();
+        tracing_subscriber::fmt::init();
 
         // ~ parse the command line arguments
         let cfg = match Config::from_cmdline() {

--- a/examples/offset-monitor.rs
+++ b/examples/offset-monitor.rs
@@ -1,7 +1,6 @@
-#[macro_use]
 use std::cmp;
 use std::env;
-use std::io::{self, stderr, stdout, BufWriter, Write};
+use std::io::{stderr, stdout, BufWriter, Write};
 use std::process;
 use std::thread;
 //use std::time as stdtime;
@@ -15,7 +14,7 @@ use kafka::client::{FetchOffset, GroupOffsetStorage, KafkaClient};
 /// the lag for a particular consumer group. Dumps the offset/lag of
 /// the monitored topic/group to stdout every few seconds.
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     macro_rules! abort {
         ($e:expr) => {{
@@ -38,7 +37,7 @@ fn main() {
 
 fn run(cfg: Config) -> Result<()> {
     let mut client = KafkaClient::new(cfg.brokers.clone());
-    client.set_group_offset_storage(cfg.offset_storage);
+    client.set_group_offset_storage(Some(cfg.offset_storage));
     client.load_metadata_all()?;
 
     // ~ if no topic specified, print all available and be done.

--- a/examples/topic-metadata.rs
+++ b/examples/topic-metadata.rs
@@ -8,7 +8,7 @@ use kafka::client::{FetchOffset, KafkaClient};
 
 /// Dumps available topic metadata to stdout.
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let cfg = match Config::from_cmdline() {
         Ok(cfg) => cfg,

--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -30,7 +30,7 @@ pub struct Builder {
     retry_max_bytes_limit: i32,
     fetch_crc_validation: bool,
     security_config: Option<SecurityConfig>,
-    group_offset_storage: GroupOffsetStorage,
+    group_offset_storage: Option<GroupOffsetStorage>,
     conn_idle_timeout: Duration,
     client_id: Option<String>,
 }
@@ -154,7 +154,7 @@ impl Builder {
     }
 
     /// See `KafkaClient::set_group_offset_storage`
-    pub fn with_offset_storage(mut self, storage: GroupOffsetStorage) -> Builder {
+    pub fn with_offset_storage(mut self, storage: Option<GroupOffsetStorage>) -> Builder {
         self.group_offset_storage = storage;
         self
     }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -16,7 +16,7 @@
 //!       .with_topic_partitions("my-topic".to_owned(), &[0, 1])
 //!       .with_fallback_offset(FetchOffset::Earliest)
 //!       .with_group("my-group".to_owned())
-//!       .with_offset_storage(GroupOffsetStorage::Kafka)
+//!       .with_offset_storage(Some(GroupOffsetStorage::Kafka))
 //!       .create()
 //!       .unwrap();
 //! loop {
@@ -409,8 +409,7 @@ impl Consumer {
     /// `Consumer::consume_messageset`.
     pub fn commit_consumed(&mut self) -> Result<()> {
         if self.config.group.is_empty() {
-            debug!("commit_consumed: ignoring commit request since no group defined");
-            return Ok(());
+            return Err(Error::UnsetGroupId);
         }
         debug!(
             "commit_consumed: commiting dirty-only consumer offsets (group: {} / offsets: {:?}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,12 @@ pub enum Error {
 
     #[error(transparent)]
     ArcSelf(#[from] Arc<Self>),
+
+    #[error("Operation requires offset storage but no offset storage was set")]
+    UnsetOffsetStorage,
+
+    #[error("Operation requires group id but no group was set")]
+    UnsetGroupId,
 }
 
 /// Various errors reported by a remote Kafka server.
@@ -187,4 +193,5 @@ pub enum KafkaCode {
     IllegalSaslState = 34,
     /// The version of API is not supported.
     UnsupportedVersion = 35,
+    // CAUTION! When adding to this list, KafkaCode::from_protocol must be updated. If there's a better way, please open an issue for it!
 }

--- a/tests/integration/client/mod.rs
+++ b/tests/integration/client/mod.rs
@@ -7,8 +7,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
 
-use env_logger;
-
 use kafka::client::fetch::Response;
 use kafka::client::{
     CommitOffset, FetchOffset, FetchPartition, PartitionOffset, ProduceMessage, RequiredAcks,
@@ -76,7 +74,7 @@ fn test_kafka_client_load_metadata() {
 /// * KafkaClient::fetch_offsets
 #[test]
 fn test_produce_fetch_messages() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
     let mut client = new_ready_kafka_client();
     let topics = [TEST_TOPIC_NAME, TEST_TOPIC_NAME_2];
     let init_latest_offsets = client.fetch_offsets(&topics, FetchOffset::Latest).unwrap();
@@ -162,7 +160,7 @@ fn test_produce_fetch_messages() {
 
 #[test]
 fn test_commit_offset() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
     let mut client = new_ready_kafka_client();
 
     for &(partition, offset) in &[

--- a/tests/integration/consumer_producer/consumer.rs
+++ b/tests/integration/consumer_producer/consumer.rs
@@ -3,12 +3,10 @@ use super::*;
 use kafka::error;
 use kafka::producer::Record;
 
-use env_logger;
-
 /// Tests that consuming one message works
 #[test]
 fn test_consumer_poll() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
 
     // poll once to set a position in the topic
     let mut consumer = test_consumer();
@@ -35,7 +33,7 @@ fn test_consumer_poll() {
 /// Test Consumer::commit_messageset
 #[test]
 fn test_consumer_commit_messageset() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
 
     let mut consumer = test_consumer();
 
@@ -95,7 +93,7 @@ fn test_consumer_commit_messageset() {
 /// message sets, nothing is committed.
 #[test]
 fn test_consumer_commit_messageset_no_consumes() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
 
     let mut consumer = test_consumer();
 

--- a/tests/integration/consumer_producer/mod.rs
+++ b/tests/integration/consumer_producer/mod.rs
@@ -34,7 +34,7 @@ macro_rules! test_consumer_config {
         $x.with_topic_partitions(TEST_TOPIC_NAME.to_owned(), &TEST_TOPIC_PARTITIONS)
             .with_group(TEST_GROUP_NAME.to_owned())
             .with_fallback_offset(kafka::consumer::FetchOffset::Latest)
-            .with_offset_storage(kafka::consumer::GroupOffsetStorage::Kafka)
+            .with_offset_storage(Some(kafka::consumer::GroupOffsetStorage::Kafka))
     };
 }
 

--- a/tests/integration/consumer_producer/producer.rs
+++ b/tests/integration/consumer_producer/producer.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use env_logger;
 use kafka::error;
 use kafka::producer::Record;
 
@@ -16,7 +15,7 @@ fn test_producer_send() {
 /// Sending to a non-existent topic should fail.
 #[test]
 fn test_producer_send_non_existent_topic() {
-    let _ = env_logger::try_init();
+    tracing_subscriber::fmt::try_init();
     let mut producer = test_producer();
 
     let error_code = match producer

--- a/tests/kafka-rust-image/Dockerfile
+++ b/tests/kafka-rust-image/Dockerfile
@@ -1,20 +1,16 @@
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get install -y curl jq coreutils net-tools openjdk-8-jre
+RUN apt-get update && apt-get install -y wget jq coreutils net-tools openjdk-8-jre
 
-ARG kafka_version=1.0.0
-ARG scala_version=2.12
+ARG kafka_version
+ARG scala_version
 
 ENV KAFKA_VERSION=$kafka_version SCALA_VERSION=$scala_version
 #ENV KAFKA_ZOOKEEPER_CONNECT zookeeper
 
-COPY download-kafka.sh /tmp/download-kafka.sh
-
-RUN /tmp/download-kafka.sh && \
-    tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && \
-    rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
-    ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka && \
-    rm /tmp/download-kafka.sh
+RUN export KAFKA_TGZ="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+    && wget -q ${KAFKA_TGZ} -O - | tar xz -C /opt \
+    && ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka
 
 RUN mkdir -p /kafka/logs
 

--- a/tests/kafka-rust-image/download-kafka.sh
+++ b/tests/kafka-rust-image/download-kafka.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-curl -Sso "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" "${url}"

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -18,6 +18,8 @@
 # `wurstmeister/kafka` repo. If there are no versions specified, it runs the tests
 # on a set of default versions.
 
+set -e
+
 stop_docker() {
   docker-compose down
 }

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -55,7 +55,7 @@ teardown() {
 
 # need to run tests serially to avoid the tests stepping on each others' toes
 export RUST_TEST_THREADS=1
-DEFAULT_VERS='0.8.2.2:0.9.0.1:0.10.2.1:0.11.0.1:1.0.0'
+DEFAULT_VERS='0.8.2.2:0.9.0.1:0.10.2.1:0.11.0.1:1.0.0:3.1.0'
 DEFAULT_COMPRESSIONS='NONE:SNAPPY:GZIP'
 DEFAULT_SECURES=':secure'
 
@@ -64,6 +64,7 @@ declare SCALA_VERS_0_9_0_1='2.11'
 declare SCALA_VERS_0_10_2_1='2.12'
 declare SCALA_VERS_0_11_0_1='2.12'
 declare SCALA_VERS_1_0_0='2.12'
+declare SCALA_VERS_3_1_0='2.13'
 
 scala_version_for_kafka() {
     local kv=$(echo $1 | sed 's/\./_/g')

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -5,13 +5,6 @@ extern crate kafka;
 extern crate rand;
 
 #[cfg(feature = "integration_tests")]
-#[macro_use]
-extern crate log;
-
-#[cfg(feature = "integration_tests")]
-extern crate env_logger;
-
-#[cfg(feature = "integration_tests")]
 extern crate openssl;
 
 #[cfg(feature = "integration_tests")]
@@ -22,6 +15,9 @@ extern crate lazy_static;
 mod integration {
     use std;
     use std::collections::HashMap;
+
+    
+    use tracing::debug;
 
     use kafka::client::{Compression, GroupOffsetStorage, KafkaClient, SecurityConfig};
 
@@ -82,7 +78,7 @@ mod integration {
             KafkaClient::new(hosts)
         };
 
-        client.set_group_offset_storage(GroupOffsetStorage::Kafka);
+        client.set_group_offset_storage(Some(GroupOffsetStorage::Kafka));
 
         let compression = std::env::var(KAFKA_CLIENT_COMPRESSION).unwrap_or(String::from(""));
         let compression = COMPRESSIONS.get(&*compression).unwrap();


### PR DESCRIPTION
Integration Tests
- Added Kafka 3.1.0
- Updated readme to reflect versions tested
- Simplified Dockerfile
- Added `set -e` to potentially catch other errors

Dependencies
- Switched logs to use 'tracing' crate instead
- Removed 'log' and 'env_logger' dependencies
- Added 'tracing-subscriber' dependency to replace 'env_logger'

Core
- Made offset storage optional
- Error during commit if offset storage or group id is empty

Examples (esp. console-consumer)
- Added --follow option
- Changed '--no-commit' to '--commit'
- Default to 'GroupOffsetStorage=None'
- etc.