### PR TITLE
doc(README.md): Send the request to the broker instead of zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ following command (where `kafka-topics.sh` is part of the Kafka
 distribution):
 
 ```
-kafka-topics.sh --topic my-topic --create --zookeeper localhost:2181 --partitions 1 --replication-factor 1
+kafka-topics.sh --topic my-topic --create --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
 ```
 
 See also [Kafka's quickstart guide](https://kafka.apache.org/documentation.html#quickstart)


### PR DESCRIPTION
Zookeeper will be removed in the next major kafka release. Using ```--bootstrap-server``` to be more ready.