### PR TITLE
bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ byteorder = "1.5"
 crc = "3.2"
 fnv = "1.0.7"
 ref_slice = "1.2.1"
-twox-hash = "1.6.3"
+twox-hash = "2.0"
 
 flate2 = { version = "1.0", optional = true }
 openssl = { version = "0.10", optional = true }
 openssl-sys = { version = "0.9", optional = true }
 snap = { version = "1.1", optional = true }
-thiserror = "1.0"
+thiserror = "2.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/src/consumer/state.rs
+++ b/src/consumer/state.rs
@@ -19,7 +19,7 @@ pub type PartitionHasher = BuildHasherDefault<FnvHasher>;
 pub struct FetchState {
     /// ~ specifies the offset which to fetch from
     pub offset: i64,
-    /// ~ specifies the `max_bytes` to be fetched 
+    /// ~ specifies the `max_bytes` to be fetched
     pub max_bytes: i32,
 }
 

--- a/src/protocol/zreader.rs
+++ b/src/protocol/zreader.rs
@@ -157,7 +157,7 @@ fn test_read_i16() {
 fn test_read_i32() {
     let data = &[1, 2, 3, 4];
     let mut r = ZReader::new(data);
-    assert_eq!(16909060, r.read_i32().unwrap());
+    assert_eq!(16_909_060, r.read_i32().unwrap());
     assert!(r.read_i32().is_err());
 
     let data = &[0xff, 0xff, 0xff, 0xfd];
@@ -170,7 +170,7 @@ fn test_read_i32() {
 fn test_read_i64() {
     let data = &[1, 2, 3, 4, 5, 6, 7, 8];
     let mut r = ZReader::new(data);
-    assert_eq!(72623859790382856, r.read_i64().unwrap());
+    assert_eq!(72_623_859_790_382_856, r.read_i64().unwrap());
     assert!(r.read_i64().is_err());
 
     let data = &[0, 0, 0, 0, 0, 0, 0, 1];

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -16,7 +16,6 @@ mod integration {
     use std;
     use std::collections::HashMap;
 
-    
     use tracing::debug;
 
     use kafka::client::{Compression, GroupOffsetStorage, KafkaClient, SecurityConfig};


### PR DESCRIPTION
- upgrade `twox-hash`: 1.6.3 -> 2.0
- upgrade `thiserror`: 1.0 -> 2.0
- also resolve clippy warnings