### PR TITLE
Feature: Migrate TLS backend to rustls 0.23 & pki-types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
             COMPRESSIONS: GZIP
             SECURES: secure
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u "${{ secrets.DOCKER_HUB_USER }}" --password-stdin
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo nextest run --all --exclude e2e_test
+          cargo nextest run --all
           cargo test --all --doc
 
       - name: Check code formatting
@@ -98,7 +98,7 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Typos check with custom config file
         uses: crate-ci/typos@master
@@ -115,9 +115,12 @@ jobs:
           - name: "Default (rustls)"
             features: ""
             extra_args: ""
-          - name: "Explicit rustls"
-            features: "security-rustls"
-            extra_args: "--no-default-features --features=snappy,gzip,security-rustls"
+          - name: "Explicit rustls (aws-lc-rs)"
+            features: "security-rustls-default"
+            extra_args: "--no-default-features --features=snappy,gzip,security-rustls-default"
+          - name: "Explicit rustls (ring)"
+            features: "security-rustls-ring"
+            extra_args: "--no-default-features --features=snappy,gzip,security-rustls-ring"
           - name: "OpenSSL (deprecated)"
             features: "security-openssl"
             extra_args: "--no-default-features --features=snappy,gzip,security-openssl"
@@ -125,7 +128,7 @@ jobs:
             features: "no-security"
             extra_args: "--no-default-features --features=snappy,gzip"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -153,7 +156,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -165,13 +168,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build for musl with rustls
-        run: cargo build --target x86_64-unknown-linux-musl --features=security-rustls --verbose
+        run: cargo build --target x86_64-unknown-linux-musl --features=security-rustls-default --verbose
 
       - name: Verify no OpenSSL dependency
         run: |
-          if ldd target/x86_64-unknown-linux-musl/debug/libkafka.* 2>/dev/null | grep -i openssl; then
-            echo "ERROR: musl build should not depend on OpenSSL!"
-            exit 1
+          # Check if the library file exists (it might be a .rlib or similar for a library crate)
+          # For a library crate, we might not produce a binary to ldd.
+          # Instead, we can check if the build succeeded without openssl-sys
+          if cargo tree --target x86_64-unknown-linux-musl --features=security-rustls-default | grep openssl-sys; then
+             echo "ERROR: musl build dependency tree contains openssl-sys!"
+             exit 1
           else
-            echo "✓ musl build is OpenSSL-free (as expected with rustls)"
+             echo "✓ musl build dependency tree is free of openssl-sys"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `security-rustls-default`: Uses `aws-lc-rs` (via `rustls/aws-lc-rs`).
     - `security-rustls-ring`: Uses `ring` (via `rustls/ring`).
 - **Certificate Handling**:
-    - Integrated `rustls-pki-types` (v1.0) with PEM support for robust certificate parsing.
+    - Integrated `rustls-pki-types` with PEM support for robust certificate parsing.
     - Integrated `rustls-native-certs` (v0.8) for loading system certificates.
     - Integrated `webpki-roots` (v1.0) as the fallback root certificate store.
 
@@ -52,21 +52,21 @@ For most users, no changes are required. The default build will now use rustls i
 If you explicitly need OpenSSL (not recommended):
 
 ```toml
-kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-openssl"] }
+kafka = { version = "0.11", default-features = false, features = ["snappy", "gzip", "security-openssl"] }
 ```
 
 To use rustls explicitly (recommended):
 
 ```toml
-kafka = { version = "0.10", features = ["security"] }
+kafka = { version = "0.11", features = ["security"] }
 # or
-kafka = { version = "0.10", features = ["security-rustls-default"] }
+kafka = { version = "0.11", features = ["security-rustls-default"] }
 ```
 
 To use rustls with `ring` crypto provider:
 
 ```toml
-kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
+kafka = { version = "0.11", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
 ```
 
 **Migrating from `rustls-pemfile` to `rustls-pki-types`**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,46 +10,52 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **rustls 0.23 TLS backend (Default)**:
-  - Replaced OpenSSL with `rustls` 0.23 as the default TLS implementation.
-  - Enabled `prefer-post-quantum` feature by default for future-proof security.
-  - Enabled `tls12` feature for broad compatibility (TLS 1.2 and 1.3 supported).
+    - Replaced OpenSSL with `rustls` 0.23 as the default TLS implementation.
+    - Enabled `prefer-post-quantum` feature by default for future-proof security.
+    - Enabled `tls12` feature for broad compatibility (TLS 1.2 and 1.3 supported).
 - **Flexible Crypto Providers**:
-  - `security-rustls-default`: Uses `aws-lc-rs` (via `rustls/aws-lc-rs`).
-  - `security-rustls-ring`: Uses `ring` (via `rustls/ring`).
+    - `security-rustls-default`: Uses `aws-lc-rs` (via `rustls/aws-lc-rs`).
+    - `security-rustls-ring`: Uses `ring` (via `rustls/ring`).
 - **Certificate Handling**:
-  - Integrated `rustls-pki-types` (v1.0) with PEM support for robust certificate parsing.
-  - Integrated `rustls-native-certs` (v0.8) for loading system certificates.
-  - Integrated `webpki-roots` (v1.0) as the fallback root certificate store.
+    - Integrated `rustls-pki-types` (v1.0) with PEM support for robust certificate parsing.
+    - Integrated `rustls-native-certs` (v0.8) for loading system certificates.
+    - Integrated `webpki-roots` (v1.0) as the fallback root certificate store.
 
 ### Changed
 
-- **BREAKING (Minor)**: The `security` feature now maps to `security-rustls-default` instead of directly depending on OpenSSL.
-  - Default TLS backend is now rustls (pure Rust) with `aws-lc-rs`
-  - Existing code using `SecurityConfig::new()` will automatically use rustls
-  - No API changes required for most users
+- **BREAKING (Minor)**: The `security` feature now maps to `security-rustls-default` instead of directly depending on
+  OpenSSL.
+    - Default TLS backend is now rustls (pure Rust) with `aws-lc-rs`
+    - Existing code using `SecurityConfig::new()` will automatically use rustls
+    - No API changes required for most users
 - **Updated Dependencies**:
-  - `rustls`: 0.21 → 0.23 (latest stable)
-  - `webpki-roots`: 0.25 → 1.0
-  - `rustls-native-certs`: 0.6 → 0.8
-  - Replaced `rustls-pemfile` with `rustls-pki-types` (feature `pem`) for type definitions and parsing.
+    - `rustls`: 0.21 → 0.23 (latest stable)
+    - `webpki-roots`: 0.25 → 1.0
+    - `rustls-native-certs`: 0.6 → 0.8
+    - Replaced `rustls-pemfile` with `rustls-pki-types` (feature `pem`) for type definitions and parsing.
+    - Replaced `lazy_static` with `std::sync::LazyLock` (requires Rust 1.80+).
+    - Replaced `crc` with `crc-fast` for improved performance.
 
 ### Deprecated
 
-- **OpenSSL backend**: The OpenSSL-based TLS implementation is now deprecated and will be removed in the next major version.
-  - Use `security-openssl` feature flag to continue using OpenSSL temporarily
-  - Migrate to rustls by using the default `security` feature
-  - See `examples/example-rustls.rs` for rustls usage examples
+- **OpenSSL backend**: The OpenSSL-based TLS implementation is now deprecated and will be removed in the next major
+  version.
+    - Use `security-openssl` feature flag to continue using OpenSSL temporarily
+    - Migrate to rustls by using the default `security` feature
+    - See `examples/example-rustls.rs` for rustls usage examples
 
 ### Migration Guide
 
 For most users, no changes are required. The default build will now use rustls instead of OpenSSL.
 
 If you explicitly need OpenSSL (not recommended):
+
 ```toml
 kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-openssl"] }
 ```
 
 To use rustls explicitly (recommended):
+
 ```toml
 kafka = { version = "0.10", features = ["security"] }
 # or
@@ -57,14 +63,17 @@ kafka = { version = "0.10", features = ["security-rustls-default"] }
 ```
 
 To use rustls with `ring` crypto provider:
+
 ```toml
 kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
 ```
 
 **Migrating from `rustls-pemfile` to `rustls-pki-types`**:
-Internal implementation now uses `rustls-pki-types` for PEM parsing. If you were using `rustls-pemfile` directly in conjunction with this crate's internals, please update to `rustls-pki-types`.
+Internal implementation now uses `rustls-pki-types` for PEM parsing. If you were using `rustls-pemfile` directly in
+conjunction with this crate's internals, please update to `rustls-pki-types`.
 
 Benefits of migrating to rustls:
+
 - No native OpenSSL dependencies required
 - Better cross-compilation support
 - Consistent TLS behavior across platforms
@@ -99,6 +108,6 @@ Benefits of migrating to rustls:
   which is what [the Kafka protocol specifies it should
   be](https://kafka.apache.org/documentation.html#theconsumer). This means that:
 
-  - When you upgrade, your consumers will read the last message it consumed again.
-  - The consumers will now be committing one offset past where they were before.
-    If you've come to rely on this behavior in any way, you should correct it.
+    - When you upgrade, your consumers will read the last message it consumed again.
+    - The consumers will now be committing one offset past where they were before.
+      If you've come to rely on this behavior in any way, you should correct it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Updated Dependencies**:
     - `rustls`: 0.21 → 0.23 (latest stable)
     - `webpki-roots`: 0.25 → 1.0
+    - `rand`: 0.8 → 0.9
     - `rustls-native-certs`: 0.6 → 0.8
     - Replaced `rustls-pemfile` with `rustls-pki-types` (feature `pem`) for type definitions and parsing.
     - Replaced `lazy_static` with `std::sync::LazyLock` (requires Rust 1.80+).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **rustls TLS backend (default)**: kafka-rust now uses rustls as the default TLS implementation, providing a pure-Rust, secure, and portable solution for TLS connections.
-  - New `security-rustls` feature flag (enabled by default via `security` feature)
-  - **Updated to rustls 0.23.35** with latest improvements and optimizations
-  - Support for webpki-roots 1.0 and rustls-native-certs 0.8 for certificate validation
-  - Support for custom CA certificates, client certificates, and hostname verification control
-  - Works out-of-the-box on musl, alpine, and other cross-compilation targets without native dependencies
+- **rustls 0.23 TLS backend (Default)**:
+  - Replaced OpenSSL with `rustls` 0.23 as the default TLS implementation.
+  - Enabled `prefer-post-quantum` feature by default for future-proof security.
+  - Enabled `tls12` feature for broad compatibility (TLS 1.2 and 1.3 supported).
+- **Flexible Crypto Providers**:
+  - `security-rustls-default`: Uses `aws-lc-rs` (via `rustls/aws-lc-rs`).
+  - `security-rustls-ring`: Uses `ring` (via `rustls/ring`).
+- **Certificate Handling**:
+  - Integrated `rustls-pki-types` (v1.0) with PEM support for robust certificate parsing.
+  - Integrated `rustls-native-certs` (v0.8) for loading system certificates.
+  - Integrated `webpki-roots` (v1.0) as the fallback root certificate store.
 
 ### Changed
 
-- **BREAKING (Minor)**: The `security` feature now maps to `security-rustls` instead of directly depending on OpenSSL.
-  - Default TLS backend is now rustls (pure Rust)
+- **BREAKING (Minor)**: The `security` feature now maps to `security-rustls-default` instead of directly depending on OpenSSL.
+  - Default TLS backend is now rustls (pure Rust) with `aws-lc-rs`
   - Existing code using `SecurityConfig::new()` will automatically use rustls
   - No API changes required for most users
-- **Updated rustls dependencies**:
-  - rustls: 0.21 → 0.23.35 (latest stable with performance improvements)
-  - webpki-roots: 0.25 → 1.0
-  - rustls-pemfile: 1.0 → 2.2
-  - rustls-native-certs: 0.6 → 0.8
+- **Updated Dependencies**:
+  - `rustls`: 0.21 → 0.23 (latest stable)
+  - `webpki-roots`: 0.25 → 1.0
+  - `rustls-native-certs`: 0.6 → 0.8
+  - Replaced `rustls-pemfile` with `rustls-pki-types` (feature `pem`) for type definitions and parsing.
 
 ### Deprecated
 
@@ -48,8 +53,16 @@ To use rustls explicitly (recommended):
 ```toml
 kafka = { version = "0.10", features = ["security"] }
 # or
-kafka = { version = "0.10", features = ["security-rustls"] }
+kafka = { version = "0.10", features = ["security-rustls-default"] }
 ```
+
+To use rustls with `ring` crypto provider:
+```toml
+kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
+```
+
+**Migrating from `rustls-pemfile` to `rustls-pki-types`**:
+Internal implementation now uses `rustls-pki-types` for PEM parsing. If you were using `rustls-pemfile` directly in conjunction with this crate's internals, please update to `rustls-pki-types`.
 
 Benefits of migrating to rustls:
 - No native OpenSSL dependencies required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "autocfg"
@@ -40,9 +31,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.0"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932a7d9d28b0d2ea34c6b3779d35e3dd6f6345317c34e73438c4f1f29144151"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -50,35 +41,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826f2e4cfc2cd19ee53c42fbf68e2f81ec21108e0b7ecf6a71cf062137360fc"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
 ]
 
 [[package]]
@@ -89,9 +59,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -101,23 +71,14 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -128,9 +89,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -140,21 +101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -177,9 +127,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -206,22 +156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -265,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -287,16 +231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -317,15 +255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -378,37 +307,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "memchr"
-version = "2.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "miniz_oxide"
@@ -418,16 +325,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -482,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -520,29 +417,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -555,20 +442,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -576,41 +462,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ring"
@@ -620,23 +477,17 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -650,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -662,18 +513,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -736,9 +587,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "smallvec"
@@ -753,12 +604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,9 +611,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -777,18 +622,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -806,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -817,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -828,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -849,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -863,13 +708,11 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "cfg-if",
  "rand",
- "static_assertions",
 ]
 
 [[package]]
@@ -910,18 +753,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -932,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -942,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -955,18 +798,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1114,24 +957,24 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -141,12 +141,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest",
+ "rustversion",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "crypto-common",
 ]
 
 [[package]]
@@ -197,6 +228,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getopts"
@@ -281,7 +322,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "chrono",
- "crc",
+ "crc-fast",
  "flate2",
  "fnv",
  "getopts",
@@ -603,6 +644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +796,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "rand",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pki-types",
  "snap",
  "thiserror",
  "tracing",
@@ -641,6 +641,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -657,15 +658,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -31,9 +31,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -53,15 +53,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -71,9 +71,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -88,10 +88,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -102,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -124,6 +135,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -187,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +233,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -267,9 +299,44 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -296,6 +363,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -327,7 +418,7 @@ dependencies = [
  "fnv",
  "getopts",
  "openssl",
- "rand",
+ "rand 0.10.1",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -346,16 +437,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
@@ -387,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -425,9 +528,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -437,15 +540,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -454,6 +557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -467,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -481,13 +594,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -497,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -508,6 +638,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ring"
@@ -525,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -562,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -580,18 +716,18 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -602,12 +738,60 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -627,9 +811,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -657,9 +841,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -740,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -758,26 +942,32 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -811,18 +1001,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -833,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -843,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -856,18 +1055,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.6"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1018,21 +1251,109 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,3 +1365,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,6 @@ dependencies = [
  "flate2",
  "fnv",
  "getopts",
- "lazy_static",
  "openssl",
  "rand",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,27 +14,27 @@ rust-version = "1.89.0"
 
 [dependencies]
 byteorder = "1.5"
-crc = "3.2"
+crc = "3.3"
 fnv = "1.0.7"
-twox-hash = "1.6.3"
+twox-hash = "2.1.2"
 
-flate2 = { version = "1.0", optional = true }
+flate2 = { version = "1.1", optional = true }
 openssl = { version = "0.10", optional = true }
 snap = { version = "1.1", optional = true }
 chrono = { version = "0.4", optional = true }
-thiserror = "1.0"
+thiserror = "2.0"
 tracing = "0.1"
 
 # rustls TLS backend (pure Rust, default)
 rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
 webpki-roots = { version = "1.0", optional = true }
-rustls-pki-types = { version = "1.0", optional = true, features = ["std"] }
+rustls-pki-types = { version = "1.14", optional = true, features = ["std"] }
 rustls-native-certs = { version = "0.8", optional = true }
 
 [dev-dependencies]
-getopts = "0.2.21"
+getopts = "0.2.24"
 tracing-subscriber = "0.3"
-rand = "0.8.5"
+rand = "0.9.2"
 lazy_static = "1.5"
 anyhow = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.89.0"
 
 [dependencies]
 byteorder = "1.5"
-crc = "3.3"
+crc-fast = "=1.9.0"
 fnv = "1.0.7"
 twox-hash = "2.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0"
 tracing = "0.1"
 
 # rustls TLS backend (pure Rust, default)
-rustls = { version = "0.23", optional = true, default-features = true, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
 webpki-roots = { version = "1.0", optional = true }
 rustls-pki-types = { version = "1.0", optional = true, features = ["std"] }
 rustls-native-certs = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ gzip = ["flate2"]
 # TLS/Security features
 # The 'security' feature now defaults to rustls (pure Rust, recommended)
 security = ["security-rustls-default"]
+security-rustls = ["security-rustls-default"]
 _security-rustls = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pki-types", "dep:rustls-native-certs"]
 security-rustls-default = ["_security-rustls", "rustls?/aws-lc-rs"]
 security-rustls-ring = ["_security-rustls", "rustls?/ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/kafka-rust/kafka-rust"
 description = "Rust client for Apache Kafka"
-rust-version = "1.85.0"
+rust-version = "1.89.0"
 
 [dependencies]
 byteorder = "1.5"
@@ -26,9 +26,9 @@ thiserror = "1.0"
 tracing = "0.1"
 
 # rustls TLS backend (pure Rust, default)
-rustls = { version = "0.23", optional = true }
+rustls = { version = "0.23", optional = true, default-features = true, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
 webpki-roots = { version = "1.0", optional = true }
-rustls-pemfile = { version = "2.2", optional = true }
+rustls-pki-types = { version = "1.0", optional = true, features = ["std"] }
 rustls-native-certs = { version = "0.8", optional = true }
 
 [dev-dependencies]
@@ -45,8 +45,10 @@ gzip = ["flate2"]
 
 # TLS/Security features
 # The 'security' feature now defaults to rustls (pure Rust, recommended)
-security = ["security-rustls"]
-security-rustls = ["rustls", "webpki-roots", "rustls-pemfile", "rustls-native-certs"]
+security = ["security-rustls-default"]
+_security-rustls = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pki-types", "dep:rustls-native-certs"]
+security-rustls-default = ["_security-rustls", "rustls?/aws-lc-rs"]
+security-rustls-ring = ["_security-rustls", "rustls?/ring"]
 # Deprecated: OpenSSL backend (will be removed in next major version)
 security-openssl = ["openssl"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,24 +18,24 @@ crc-fast = "=1.9.0"
 fnv = "1.0.7"
 twox-hash = "2.1.2"
 
-flate2 = { version = "1.1", optional = true }
-openssl = { version = "0.10", optional = true }
-snap = { version = "1.1", optional = true }
-chrono = { version = "0.4", optional = true }
-thiserror = "2.0"
-tracing = "0.1"
+flate2 = { version = "1.1.9", optional = true }
+openssl = { version = "0.10.78", optional = true }
+snap = { version = "1.1.1", optional = true }
+chrono = { version = "0.4.44", optional = true }
+thiserror = "2.0.18"
+tracing = "0.1.44"
 
 # rustls TLS backend (pure Rust, default)
-rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
-webpki-roots = { version = "1.0", optional = true }
-rustls-pki-types = { version = "1.14", optional = true, features = ["std"] }
-rustls-native-certs = { version = "0.8", optional = true }
+rustls = { version = "0.23.38", optional = true, default-features = false, features = ["logging", "prefer-post-quantum", "std", "tls12"] }
+webpki-roots = { version = "1.0.7", optional = true }
+rustls-pki-types = { version = "1.14.0", optional = true, features = ["std"] }
+rustls-native-certs = { version = "0.8.3", optional = true }
 
 [dev-dependencies]
 getopts = "0.2.24"
-tracing-subscriber = "0.3"
-rand = "0.9.2"
-anyhow = "1.0"
+tracing-subscriber = "0.3.23"
+rand = "0.10.1"
+anyhow = "1.0.102"
 
 [features]
 default = ["snappy", "gzip", "security"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ rustls-native-certs = { version = "0.8", optional = true }
 getopts = "0.2.24"
 tracing-subscriber = "0.3"
 rand = "0.9.2"
-lazy_static = "1.5"
 anyhow = "1.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ See kafka-rust's `Cargo.toml` and [cargo's documentation](http://doc.crates.io/m
 
 **kafka-rust** now uses **rustls** as the default TLS backend, providing a pure-Rust, secure, and portable TLS implementation.
 
+#### Available Security Features
+
+The crate supports the following security features:
+- `security-rustls-default`: Uses `rustls` with `aws-lc-rs` as the crypto provider (Default).
+- `security-rustls-ring`: Uses `rustls` with `ring` as the crypto provider.
+- `security-openssl`: Uses `openssl` (Deprecated).
+
+The default `security` feature is an alias for `security-rustls-default`.
+
 #### Using rustls (Default, Recommended)
 
 rustls is enabled by default and requires no additional system dependencies:
@@ -42,12 +51,36 @@ rustls is enabled by default and requires no additional system dependencies:
 kafka = { version = "0.10", features = ["security"] }
 ```
 
+To use `ring` instead of `aws-lc-rs`:
+
+```toml
+[dependencies]
+kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
+```
+
 Benefits of rustls:
 - ✅ Pure Rust implementation - no native dependencies
 - ✅ Better cross-compilation support (musl, alpine, etc.)
 - ✅ Modern TLS 1.2+ only
 - ✅ Simpler builds - no OpenSSL development libraries required
 - ✅ Consistent behavior across platforms
+
+**Note:** rustls requires TLS 1.2+. Legacy TLS 1.0/1.1 not supported.
+
+#### Migrating from OpenSSL to rustls (v0.10+)
+
+Before (OpenSSL):
+```rust
+let connector = SslConnector::builder(SslMethod::tls()).unwrap().build();
+let security = SecurityConfig::new_openssl(connector); // Deprecated!
+```
+
+After (rustls):
+```rust
+let security = SecurityConfig::new()
+    .with_ca_cert(ca_path)
+    .with_client_cert(cert_path, key_path);
+```
 
 #### Using OpenSSL (Deprecated)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ expect the version number to grow quickly).
 
 ```toml
 [dependencies]
-kafka = "0.10"
+kafka = "0.11"
 ```
 
 To build kafka-rust the usual `cargo build` should suffice. The crate
@@ -48,14 +48,14 @@ rustls is enabled by default and requires no additional system dependencies:
 
 ```toml
 [dependencies]
-kafka = { version = "0.10", features = ["security"] }
+kafka = { version = "0.11", features = ["security"] }
 ```
 
 To use `ring` instead of `aws-lc-rs`:
 
 ```toml
 [dependencies]
-kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
+kafka = { version = "0.11", default-features = false, features = ["snappy", "gzip", "security-rustls-ring"] }
 ```
 
 Benefits of rustls:
@@ -88,7 +88,7 @@ For backward compatibility, OpenSSL support is still available but deprecated:
 
 ```toml
 [dependencies]
-kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip", "security-openssl"] }
+kafka = { version = "0.11", default-features = false, features = ["snappy", "gzip", "security-openssl"] }
 ```
 
 **⚠️ Note:** OpenSSL backend will be removed in the next major version. Please migrate to rustls.
@@ -99,7 +99,7 @@ To build without any TLS support:
 
 ```toml
 [dependencies]
-kafka = { version = "0.10", default-features = false, features = ["snappy", "gzip"] }
+kafka = { version = "0.11", default-features = false, features = ["snappy", "gzip"] }
 ```
 
 ## Supported Kafka version

--- a/examples/console-consumer.rs
+++ b/examples/console-consumer.rs
@@ -45,7 +45,7 @@ fn process(cfg: Config) -> Result<()> {
         for topic in cfg.topics {
             cb = cb.with_topic(topic);
         }
-        cb.create().unwrap()
+        cb.create()?
     };
 
     let stdout = io::stdout();
@@ -53,7 +53,7 @@ fn process(cfg: Config) -> Result<()> {
     let mut buf = Vec::with_capacity(1024);
 
     loop {
-        for ms in c.poll().unwrap().into_iter() {
+        for ms in c.poll()?.into_iter() {
             for m in ms.messages() {
                 // ~ clear the output buffer
                 unsafe { buf.set_len(0) };

--- a/examples/example-rustls.rs
+++ b/examples/example-rustls.rs
@@ -158,8 +158,8 @@ mod example {
     use std::process;
 
     pub fn main() {
-        println!("example relevant only with the \"security-rustls\" feature enabled!");
-        println!("Try: cargo run --example example-rustls --features=security-rustls");
+        println!("example relevant only with a rustls security feature enabled!");
+        println!("Try: cargo run --example example-rustls --features=security-rustls-default");
         process::exit(1);
     }
 }

--- a/examples/example-rustls.rs
+++ b/examples/example-rustls.rs
@@ -2,7 +2,7 @@ fn main() {
     example::main();
 }
 
-#[cfg(feature = "security-rustls")]
+#[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
 mod example {
     use kafka;
     use tracing::info;
@@ -153,7 +153,7 @@ mod example {
     }
 }
 
-#[cfg(not(feature = "security-rustls"))]
+#[cfg(not(any(feature = "security-rustls-default", feature = "security-rustls-ring")))]
 mod example {
     use std::process;
 

--- a/examples/offset-monitor.rs
+++ b/examples/offset-monitor.rs
@@ -118,9 +118,9 @@ impl State {
         group: &str,
     ) -> Result<()> {
         // ~ get the latest topic offsets
-        let latests = client.fetch_topic_offsets(topic, FetchOffset::Latest)?;
+        let latest = client.fetch_topic_offsets(topic, FetchOffset::Latest)?;
 
-        for l in latests {
+        for l in latest {
             let off = self
                 .offsets
                 .get_mut(l.partition as usize)

--- a/examples/offset-monitor.rs
+++ b/examples/offset-monitor.rs
@@ -233,7 +233,7 @@ impl<W: Write> Printer<W> {
             use std::fmt::Write;
 
             self.fmt_buf.clear();
-            let _ = write!(self.fmt_buf, "{}", time.elapsed().unwrap().as_secs());
+            let _ = write!(self.fmt_buf, "{}", time.elapsed()?.as_secs());
             let _ = write!(self.out_buf, "{1:<0$}", self.time_width, self.fmt_buf);
             if self.print_summary {
                 let mut prev_latest = 0;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -331,7 +331,7 @@ pub struct FetchPartition<'a> {
     /// The offset as of which to fetch messages.
     pub offset: i64,
 
-    /// The partition to fetch messasges from.
+    /// The partition to fetch messages from.
     pub partition: i32,
 
     /// Specifies the max. amount of data to fetch (for this
@@ -1129,7 +1129,7 @@ impl KafkaClient {
     ///
     /// Note: before using this method consider using
     /// `kafka::consumer::Consumer` instead which provides an easier
-    /// to use API for the regular use-case of fetching messesage from
+    /// to use API for the regular use-case of fetching messages from
     /// Kafka.
     ///
     /// # Example
@@ -1502,7 +1502,7 @@ fn __get_group_coordinator<'a>(
     now: Instant,
 ) -> Result<&'a str> {
     if let Some(host) = state.group_coordinator(group) {
-        // ~ decouple the lifetimes to make borrowck happy;
+        // ~ decouple the lifetimes to make borrow-ck happy;
         // this is actually safe since we're immediately
         // returning this, so the follow up code is not
         // affected here
@@ -1512,7 +1512,7 @@ fn __get_group_coordinator<'a>(
     let req = protocol::GroupCoordinatorRequest::new(group, correlation_id, &config.client_id);
     let mut attempt = 1;
     loop {
-        // ~ idealy we'd make this work even if `load_metadata` has not
+        // ~ ideally we'd make this work even if `load_metadata` has not
         // been called yet; if there are no connections available we can
         // try connecting to the user specified bootstrap server similar
         // to the way `load_metadata` works.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,6 +7,8 @@
 // pub re-export
 pub use crate::compression::Compression;
 use crate::protocol::list_offset::ListOffsetVersion;
+#[cfg(feature = "producer_timestamp")]
+pub use crate::protocol::produce::ProducerTimestamp;
 pub use crate::utils::PartitionOffset;
 use crate::utils::TimestampedPartitionOffset;
 use std;
@@ -19,13 +21,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tracing::{debug, trace};
 
-#[cfg(feature = "producer_timestamp")]
-pub use crate::protocol::produce::ProducerTimestamp;
-
 #[cfg(not(feature = "producer_timestamp"))]
 use crate::protocol::produce::ProducerTimestamp;
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 pub use self::network::SecurityConfig;
 
 use crate::codecs::{FromByte, ToByte};
@@ -454,7 +457,11 @@ impl KafkaClient {
     /// and [openssl_verify](https://crates.io/crates/openssl-verify),
     /// as well as
     /// [Kafka's documentation](https://kafka.apache.org/documentation.html#security_ssl).
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     #[must_use]
     pub fn new_secure(hosts: Vec<String>, security: SecurityConfig) -> KafkaClient {
         KafkaClient {

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -14,13 +14,20 @@ use std::time::{Duration, Instant};
 use tracing::{debug, trace, warn};
 
 // Import TLS types based on enabled features
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 use crate::tls::{TlsConfig, TlsStream};
 
-#[cfg(feature = "security-rustls")]
+#[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
 use crate::tls::RustlsConnector;
 
-#[cfg(all(feature = "security-openssl", not(feature = "security-rustls")))]
+#[cfg(all(
+    feature = "security-openssl",
+    not(any(feature = "security-rustls-default", feature = "security-openssl"))
+))]
 use crate::tls::OpenSslConnector;
 
 // --------------------------------------------------------------------
@@ -29,12 +36,20 @@ use crate::tls::OpenSslConnector;
 ///
 /// This configuration is now backend-agnostic and works with both
 /// rustls (default) and OpenSSL (deprecated) TLS implementations.
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 pub struct SecurityConfig {
     tls_config: TlsConfig,
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl SecurityConfig {
     /// Create a new `SecurityConfig` with default TLS settings.
     ///
@@ -102,14 +117,22 @@ impl SecurityConfig {
     }
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl fmt::Debug for SecurityConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -150,12 +173,20 @@ impl<T: fmt::Debug> fmt::Debug for Pooled<T> {
 pub struct Config {
     rw_timeout: Option<Duration>,
     idle_timeout: Duration,
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     security_config: Option<SecurityConfig>,
 }
 
 impl Config {
-    #[cfg(not(any(feature = "security-rustls", feature = "security-openssl")))]
+    #[cfg(not(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    )))]
     fn new_conn(&self, id: u32, host: &str) -> Result<KafkaConnection> {
         KafkaConnection::new(id, host, self.rw_timeout).map(|c| {
             debug!("Established: {:?}", c);
@@ -163,7 +194,11 @@ impl Config {
         })
     }
 
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     fn new_conn(&self, id: u32, host: &str) -> Result<KafkaConnection> {
         KafkaConnection::new(
             id,
@@ -203,7 +238,11 @@ pub struct Connections {
 }
 
 impl Connections {
-    #[cfg(not(any(feature = "security-rustls", feature = "security-openssl")))]
+    #[cfg(not(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    )))]
     pub fn new(rw_timeout: Option<Duration>, idle_timeout: Duration) -> Connections {
         Connections {
             conns: HashMap::new(),
@@ -215,12 +254,20 @@ impl Connections {
         }
     }
 
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     pub fn new(rw_timeout: Option<Duration>, idle_timeout: Duration) -> Connections {
         Self::new_with_security(rw_timeout, idle_timeout, None)
     }
 
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     pub fn new_with_security(
         rw_timeout: Option<Duration>,
         idle_timeout: Duration,
@@ -297,10 +344,18 @@ impl Connections {
 // --------------------------------------------------------------------
 
 // Abstraction for stream types based on security features
-#[cfg(not(any(feature = "security-rustls", feature = "security-openssl")))]
+#[cfg(not(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+)))]
 type KafkaStream = TcpStream;
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 enum KafkaStream {
     Plain(TcpStream),
     Tls(Box<dyn TlsStream>),
@@ -314,7 +369,11 @@ trait StreamOps {
     fn shutdown(&mut self, how: Shutdown) -> std::io::Result<()>;
 }
 
-#[cfg(not(any(feature = "security-rustls", feature = "security-openssl")))]
+#[cfg(not(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+)))]
 impl StreamOps for KafkaStream {
     fn is_secured(&self) -> bool {
         false
@@ -333,7 +392,11 @@ impl StreamOps for KafkaStream {
     }
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl StreamOps for KafkaStream {
     fn is_secured(&self) -> bool {
         match self {
@@ -364,7 +427,11 @@ impl StreamOps for KafkaStream {
     }
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl Read for KafkaStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
@@ -374,7 +441,11 @@ impl Read for KafkaStream {
     }
 }
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 impl Write for KafkaStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
@@ -454,12 +525,20 @@ impl KafkaConnection {
         })
     }
 
-    #[cfg(not(any(feature = "security-rustls", feature = "security-openssl")))]
+    #[cfg(not(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    )))]
     fn new(id: u32, host: &str, rw_timeout: Option<Duration>) -> Result<KafkaConnection> {
         KafkaConnection::from_stream(TcpStream::connect(host)?, id, host, rw_timeout)
     }
 
-    #[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     fn new(
         id: u32,
         host: &str,
@@ -477,14 +556,20 @@ impl KafkaConnection {
                 };
 
                 // Create appropriate TLS connector based on enabled features
-                #[cfg(feature = "security-rustls")]
+                #[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
                 {
                     let connector = RustlsConnector::new(config)?;
                     let tls_stream = connector.connect(domain, tcp_stream)?;
                     KafkaStream::Tls(tls_stream)
                 }
 
-                #[cfg(all(feature = "security-openssl", not(feature = "security-rustls")))]
+                #[cfg(all(
+                    feature = "security-openssl",
+                    not(any(
+                        feature = "security-rustls-default",
+                        feature = "security-rustls-ring"
+                    ))
+                ))]
                 {
                     #[allow(deprecated)]
                     let connector = OpenSslConnector::new(config)?;

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -26,7 +26,7 @@ use crate::tls::RustlsConnector;
 
 #[cfg(all(
     feature = "security-openssl",
-    not(any(feature = "security-rustls-default", feature = "security-openssl"))
+    not(any(feature = "security-rustls-default", feature = "security-rustls-ring"))
 ))]
 use crate::tls::OpenSslConnector;
 

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -302,7 +302,7 @@ impl Connections {
             }
             conn.last_checkout = now;
             let kconn: &mut KafkaConnection = &mut conn.item;
-            // ~ decouple the lifetimes to make the borrowck happy;
+            // ~ decouple the lifetimes to make the borrow-ck happy;
             // this is safe since we're immediately returning the
             // reference and the rest of the code in this method is
             // not affected
@@ -493,7 +493,7 @@ impl KafkaConnection {
     }
 
     pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        let r = (self.stream).read_exact(buf).map_err(From::from);
+        let r = self.stream.read_exact(buf).map_err(From::from);
         trace!("Read {} bytes from: {:?} => {:?}", buf.len(), self, r);
         r
     }

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -403,11 +403,10 @@ impl ClientState {
                 host: group_host,
             });
         }
-        if let Some(br) = self.group_coordinators.get_mut(group) {
-            if br._index != broker_ref._index {
+        if let Some(br) = self.group_coordinators.get_mut(group)
+            && br._index != broker_ref._index {
                 br._index = broker_ref._index;
             }
-        }
         self.group_coordinators.insert(group.to_owned(), broker_ref);
         &self.brokers[broker_ref.index()].host
     }

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -404,9 +404,10 @@ impl ClientState {
             });
         }
         if let Some(br) = self.group_coordinators.get_mut(group)
-            && br._index != broker_ref._index {
-                br._index = broker_ref._index;
-            }
+            && br._index != broker_ref._index
+        {
+            br._index = broker_ref._index;
+        }
         self.group_coordinators.insert(group.to_owned(), broker_ref);
         &self.brokers[broker_ref.index()].host
     }

--- a/src/compression/snappy.rs
+++ b/src/compression/snappy.rs
@@ -31,7 +31,7 @@ fn uncompress_to(src: &[u8], dst: &mut Vec<u8>) -> Result<()> {
 
 const MAGIC: &[u8] = &[0x82, b'S', b'N', b'A', b'P', b'P', b'Y', 0];
 
-// ~ reads a i32 valud and "advances" the given slice by four bytes;
+// ~ reads a i32 value and "advances" the given slice by four bytes;
 // assumes "slice" is a mutable reference to a &[u8].
 macro_rules! next_i32 {
     ($slice:expr) => {{

--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -9,10 +9,18 @@ use super::config::Config;
 use super::state::State;
 use super::{Consumer, DEFAULT_FALLBACK_OFFSET, DEFAULT_RETRY_MAX_BYTES_LIMIT};
 
-#[cfg(feature = "security")]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 use crate::client::SecurityConfig;
 
-#[cfg(not(feature = "security"))]
+#[cfg(not(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+)))]
 type SecurityConfig = ();
 
 /// A Kafka Consumer builder easing the process of setting up various
@@ -109,7 +117,11 @@ impl Builder {
 
     /// Specifies the security config to use.
     /// See `KafkaClient::new_secure` for more info.
-    #[cfg(feature = "security")]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     #[must_use]
     pub fn with_security(mut self, sec: SecurityConfig) -> Builder {
         self.security_config = Some(sec);
@@ -213,13 +225,21 @@ impl Builder {
         self
     }
 
-    #[cfg(not(feature = "security"))]
+    #[cfg(not(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    )))]
     #[must_use]
     fn new_kafka_client(hosts: Vec<String>, _: Option<SecurityConfig>) -> KafkaClient {
         KafkaClient::new(hosts)
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     fn new_kafka_client(hosts: Vec<String>, security: Option<SecurityConfig>) -> KafkaClient {
         if let Some(security) = security {
             KafkaClient::new_secure(hosts, security)

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -64,7 +64,6 @@
 use crate::client::fetch;
 use crate::client::{CommitOffset, FetchPartition, KafkaClient};
 use crate::error::{Error, KafkaCode, Result};
-use crate::protocol;
 use std::collections::hash_map::{Entry, HashMap};
 use std::slice;
 use tracing::debug;
@@ -98,7 +97,7 @@ pub struct Consumer {
 }
 
 // XXX 1) Allow returning to a previous offset (aka seeking)
-// XXX 2) Issue IO in a separate (background) thread and pre-fetch messagesets
+// XXX 2) Issue IO in a separate (background) thread and pre-fetch message sets
 
 impl Consumer {
     /// Starts building a consumer using the given kafka client.
@@ -107,7 +106,7 @@ impl Consumer {
         builder::new(Some(client), Vec::new())
     }
 
-    /// Starts building a consumer bootstraping internally a new kafka
+    /// Starts building a consumer bootstrapping internally a new kafka
     /// client from the given kafka hosts.
     #[must_use]
     pub fn from_hosts(hosts: Vec<String>) -> Builder {
@@ -200,10 +199,10 @@ impl Consumer {
     /// let mut client = KafkaClient::new(vec!["localhost:9092".to_owned()]);
     /// client.load_metadata_all().unwrap();
     /// let topics = vec!["test-topic".to_string()];
-    /// let tpos = client.list_offsets(&topics, FetchOffset::ByTime(1698425676797)).unwrap();
+    /// let typos = client.list_offsets(&topics, FetchOffset::ByTime(1698425676797)).unwrap();
     ///
     /// // Seek to the offsets
-    /// for (topic, partition_offsets) in tpos {
+    /// for (topic, partition_offsets) in typos {
     ///     for po in partition_offsets {
     ///         consumer.seek(&topic, po.partition, po.offset).unwrap();
     ///     }
@@ -300,7 +299,7 @@ impl Consumer {
                     .expect("unknown topic in response");
 
                 for p in t.partitions() {
-                    let tp = state::TopicPartition {
+                    let tp = TopicPartition {
                         topic_ref,
                         partition: p.partition(),
                     };
@@ -415,7 +414,7 @@ impl Consumer {
         self.state
             .topic_ref(topic)
             .and_then(|tref| {
-                self.state.consumed_offsets.get(&state::TopicPartition {
+                self.state.consumed_offsets.get(&TopicPartition {
                     topic_ref: tref,
                     partition,
                 })
@@ -440,7 +439,7 @@ impl Consumer {
             .topic_ref(topic)
             .ok_or_else(|| Error::Kafka(KafkaCode::UnknownTopicOrPartition))?;
 
-        let tp = state::TopicPartition {
+        let tp = TopicPartition {
             topic_ref,
             partition,
         };
@@ -613,7 +612,7 @@ impl<'a> Iterator for MessageSetsIter<'a> {
                 if let Some(messages) = p
                     .data()
                     .ok()
-                    .map(protocol::fetch::Data::messages)
+                    .map(fetch::Data::messages)
                     .filter(|msgs| !msgs.is_empty())
                 {
                     return Some(MessageSet {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -199,10 +199,10 @@ impl Consumer {
     /// let mut client = KafkaClient::new(vec!["localhost:9092".to_owned()]);
     /// client.load_metadata_all().unwrap();
     /// let topics = vec!["test-topic".to_string()];
-    /// let typos = client.list_offsets(&topics, FetchOffset::ByTime(1698425676797)).unwrap();
+    /// let topic_offsets = client.list_offsets(&topics, FetchOffset::ByTime(1698425676797)).unwrap();
     ///
     /// // Seek to the offsets
-    /// for (topic, partition_offsets) in typos {
+    /// for (topic, partition_offsets) in topic_offsets {
     ///     for po in partition_offsets {
     ///         consumer.seek(&topic, po.partition, po.offset).unwrap();
     ///     }

--- a/src/consumer/state.rs
+++ b/src/consumer/state.rs
@@ -14,7 +14,7 @@ use super::config::Config;
 
 pub type PartitionHasher = BuildHasherDefault<FnvHasher>;
 
-// The "fetch state" for a particular topci partition.
+// The "fetch state" for a particular topic partition.
 #[derive(Debug)]
 pub struct FetchState {
     /// ~ specifies the offset which to fetch from
@@ -35,7 +35,7 @@ pub struct TopicPartition {
 pub struct ConsumedOffset {
     /// ~ the consumed offset
     pub offset: i64,
-    /// ~ true if the consumed offset is chnaged but not committed to
+    /// ~ true if the consumed offset is changed but not committed to
     /// kafka yet
     pub dirty: bool,
 }
@@ -203,7 +203,7 @@ fn load_consumed_offsets(
         return Ok(offs);
     }
     // ~ otherwise try load them for the group
-    let tpos = client.fetch_group_offsets(
+    let typos = client.fetch_group_offsets(
         group,
         subscriptions.iter().flat_map(|s| {
             let topic = s.assignment.topic();
@@ -212,7 +212,7 @@ fn load_consumed_offsets(
                 .map(move |&p| FetchGroupOffset::new(topic, p))
         }),
     )?;
-    for (topic, pos) in tpos {
+    for (topic, pos) in typos {
         for po in pos {
             if po.offset != -1 {
                 offs.insert(
@@ -253,11 +253,11 @@ fn load_fetch_states(
     ) -> Result<HashMap<String, HashMap<i32, i64, PartitionHasher>>> {
         let toffs = client.fetch_offsets(topics, offset)?;
         let mut m = HashMap::with_capacity(toffs.len());
-        for (topic, poffs) in toffs {
+        for (topic, offs) in toffs {
             let mut pidx =
-                HashMap::with_capacity_and_hasher(poffs.len(), PartitionHasher::default());
+                HashMap::with_capacity_and_hasher(offs.len(), PartitionHasher::default());
 
-            for poff in poffs {
+            for poff in offs {
                 pidx.insert(poff.partition, poff.offset);
             }
 

--- a/src/consumer/state.rs
+++ b/src/consumer/state.rs
@@ -203,7 +203,7 @@ fn load_consumed_offsets(
         return Ok(offs);
     }
     // ~ otherwise try load them for the group
-    let typos = client.fetch_group_offsets(
+    let topic_offsets = client.fetch_group_offsets(
         group,
         subscriptions.iter().flat_map(|s| {
             let topic = s.assignment.topic();
@@ -212,7 +212,7 @@ fn load_consumed_offsets(
                 .map(move |&p| FetchGroupOffset::new(topic, p))
         }),
     )?;
-    for (topic, pos) in typos {
+    for (topic, pos) in topic_offsets {
         for po in pos {
             if po.offset != -1 {
                 offs.insert(

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
 
-    #[cfg(feature = "security-rustls")]
+    #[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
     #[error("TLS Error: {0}")]
     Rustls(String),
 
@@ -20,7 +20,7 @@ pub enum Error {
 
     #[cfg(feature = "snappy")]
     #[error(transparent)]
-    InvalidSnappy(#[from] ::snap::Error),
+    InvalidSnappy(#[from] snap::Error),
 
     /// An error as reported by a remote Kafka server
     #[error("Kafka Error ({0:?})")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@ pub mod producer;
 mod protocol;
 mod utils;
 
-#[cfg(any(feature = "security-rustls", feature = "security-openssl"))]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 mod tls;
 
 pub use self::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Clients for comunicating with a [Kafka](http://kafka.apache.org/)
+//! Clients for communicating with a [Kafka](http://kafka.apache.org/)
 //! cluster.  These are:
 //!
 //! - `kafka::producer::Producer` - for sending message to Kafka

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -71,11 +71,20 @@ use twox_hash::XxHash32;
 #[cfg(feature = "producer_timestamp")]
 use crate::protocol::produce::ProducerTimestamp;
 
-#[cfg(feature = "security")]
+#[cfg(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+))]
 use crate::client::SecurityConfig;
 
-#[cfg(not(feature = "security"))]
+#[cfg(not(any(
+    feature = "security-rustls-default",
+    feature = "security-rustls-ring",
+    feature = "security-openssl"
+)))]
 type SecurityConfig = ();
+
 use crate::client_internals::KafkaClientInternals;
 use crate::protocol;
 
@@ -389,7 +398,11 @@ impl Builder {
 
     /// Specifies the security config to use.
     /// See `KafkaClient::new_secure` for more info.
-    #[cfg(feature = "security")]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     #[must_use]
     pub fn with_security(mut self, security: SecurityConfig) -> Self {
         self.security_config = Some(security);
@@ -471,12 +484,20 @@ impl<P> Builder<P> {
         }
     }
 
-    #[cfg(not(feature = "security"))]
+    #[cfg(not(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    )))]
     fn new_kafka_client(hosts: Vec<String>, _: Option<SecurityConfig>) -> KafkaClient {
         KafkaClient::new(hosts)
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(any(
+        feature = "security-rustls-default",
+        feature = "security-rustls-ring",
+        feature = "security-openssl"
+    ))]
     fn new_kafka_client(hosts: Vec<String>, security: Option<SecurityConfig>) -> KafkaClient {
         if let Some(security) = security {
             KafkaClient::new_secure(hosts, security)
@@ -572,7 +593,7 @@ impl<'a> Topics<'a> {
         Topics { partitions }
     }
 
-    /// Retrieves informationa about a topic's partitions.
+    /// Retrieves information about a topic's partitions.
     #[inline]
     #[must_use]
     pub fn partitions(&'a self, topic: &str) -> Option<&'a Partitions> {
@@ -777,7 +798,7 @@ mod default_partitioner_tests {
         // to different partitions)
         let h3 = assert_partitioning(&h, &mut p, "foo", "foo-key");
         let h4 = assert_partitioning(&h, &mut p, "foo", "bar-key");
-        assert!(h3 != h4);
+        assert_ne!(h3, h4);
     }
 
     #[derive(Default)]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -244,7 +244,7 @@ impl Producer {
         Builder::new(Some(client), Vec::new())
     }
 
-    /// Starts building a producer bootstraping internally a new kafka
+    /// Starts building a producer bootstrapping internally a new kafka
     /// client from the given kafka hosts.
     #[must_use]
     pub fn from_hosts(hosts: Vec<String>) -> Builder<DefaultPartitioner> {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use crate::codecs::{FromByte, ToByte};
 use crate::error::{Error, KafkaCode, Result};
-use crc::Crc;
 
 /// Macro to return Result<()> from multiple statements
 macro_rules! try_multi {
@@ -164,12 +163,16 @@ impl FromByte for HeaderResponse {
 // --------------------------------------------------------------------
 
 pub fn to_crc(data: &[u8]) -> u32 {
-    Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(data)
+    to_crc_u64(data) as u32
+}
+
+pub fn to_crc_u64(data: &[u8]) -> u64 {
+    crc_fast::checksum(crc_fast::CrcAlgorithm::Crc32IsoHdlc, data)
 }
 
 // --------------------------------------------------------------------
 
-/// Safely converts a Duration into the number of milliseconds as a
+/// Safely converts a Duration into the number of milliseconds as an
 /// i32 as often required in the kafka protocol.
 pub fn to_millis_i32(d: Duration) -> Result<i32> {
     let m = d

--- a/src/protocol/produce.rs
+++ b/src/protocol/produce.rs
@@ -309,7 +309,7 @@ impl MessageProduceRequest<'_> {
     //
     // note: the rendered data corresponds to a single MessageSet in the kafka protocol
     fn _encode_to_buf(&self, buffer: &mut Vec<u8>, magic: i8, attributes: i8) -> Result<()> {
-        (0i64).encode(buffer)?; // offset in the response request can be anything
+        0i64.encode(buffer)?; // offset in the response request can be anything
 
         let size_pos = buffer.len();
         let mut size: i32 = 0;

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -13,7 +13,10 @@ pub mod rustls_connector;
 #[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
 pub use rustls_connector::RustlsConnector;
 
-#[cfg(feature = "security-openssl")]
+#[cfg(all(
+    feature = "security-openssl",
+    not(any(feature = "security-rustls-default", feature = "security-rustls-ring"))
+))]
 pub mod openssl_connector;
 #[cfg(all(
     feature = "security-openssl",

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -8,14 +8,17 @@ use std::io;
 use std::net::TcpStream;
 
 // Re-export the appropriate connector based on enabled features
-#[cfg(feature = "security-rustls")]
+#[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
 pub mod rustls_connector;
-#[cfg(feature = "security-rustls")]
+#[cfg(any(feature = "security-rustls-default", feature = "security-rustls-ring"))]
 pub use rustls_connector::RustlsConnector;
 
 #[cfg(feature = "security-openssl")]
 pub mod openssl_connector;
-#[cfg(all(feature = "security-openssl", not(feature = "security-rustls")))]
+#[cfg(all(
+    feature = "security-openssl",
+    not(any(feature = "security-rustls-default", feature = "security-rustls-ring"))
+))]
 pub use openssl_connector::OpenSslConnector;
 
 /// Configuration for TLS connections

--- a/src/tls/rustls_connector.rs
+++ b/src/tls/rustls_connector.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::{TlsConfig, TlsStream};
-use rustls::pki_types::{CertificateDer, ServerName};
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
 use tracing::{debug, warn};
 
@@ -72,6 +73,44 @@ pub struct RustlsConnector {
 impl RustlsConnector {
     /// Create a new rustls connector with the given configuration
     pub fn new(tls_config: &TlsConfig) -> io::Result<Self> {
+        let root_store = Self::load_root_store(tls_config)?;
+
+        let provider = {
+            #[cfg(feature = "security-rustls-ring")]
+            {
+                rustls::crypto::ring::default_provider()
+            }
+            #[cfg(not(feature = "security-rustls-ring"))]
+            {
+                rustls::crypto::aws_lc_rs::default_provider()
+            }
+        };
+
+        let config_builder = ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to set protocol versions: {e}"),
+                )
+            })?
+            .with_root_certificates(root_store);
+
+        let config = if let (Some(cert_path), Some(key_path)) =
+            (&tls_config.client_cert_path, &tls_config.client_key_path)
+        {
+            Self::load_client_auth(config_builder, cert_path, key_path)?
+        } else {
+            config_builder.with_no_client_auth()
+        };
+
+        Ok(RustlsConnector {
+            config: Arc::new(config),
+            verify_hostname: tls_config.verify_hostname,
+        })
+    }
+
+    fn load_root_store(tls_config: &TlsConfig) -> io::Result<RootCertStore> {
         let mut root_store = RootCertStore::empty();
 
         // Load CA certificates
@@ -85,7 +124,7 @@ impl RustlsConnector {
             })?;
             let mut ca_reader = BufReader::new(ca_file);
 
-            let certs: Vec<CertificateDer> = rustls_pemfile::certs(&mut ca_reader)
+            let certs: Vec<CertificateDer> = CertificateDer::pem_reader_iter(&mut ca_reader)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| {
                     io::Error::new(
@@ -118,65 +157,53 @@ impl RustlsConnector {
                 );
             }
         }
+        Ok(root_store)
+    }
 
-        let config_builder = ClientConfig::builder().with_root_certificates(root_store);
+    fn load_client_auth(
+        builder: rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>,
+        cert_path: &str,
+        key_path: &str,
+    ) -> io::Result<ClientConfig> {
+        // Load client certificate if provided
+        let cert_file = File::open(cert_path).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Failed to open client cert file: {e}"),
+            )
+        })?;
+        let mut cert_reader = BufReader::new(cert_file);
 
-        let config = if let (Some(cert_path), Some(key_path)) =
-            (&tls_config.client_cert_path, &tls_config.client_key_path)
-        {
-            // Load client certificate if provided
-            let cert_file = File::open(cert_path).map_err(|e| {
+        let certs: Vec<CertificateDer> = CertificateDer::pem_reader_iter(&mut cert_reader)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
                 io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("Failed to open client cert file: {e}"),
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to parse client cert: {e}"),
                 )
             })?;
-            let mut cert_reader = BufReader::new(cert_file);
 
-            let certs: Vec<CertificateDer> = rustls_pemfile::certs(&mut cert_reader)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to parse client cert: {e}"),
-                    )
-                })?;
+        let key_file = File::open(key_path).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Failed to open client key file: {e}"),
+            )
+        })?;
+        let mut key_reader = BufReader::new(key_file);
 
-            let key_file = File::open(key_path).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("Failed to open client key file: {e}"),
-                )
-            })?;
-            let mut key_reader = BufReader::new(key_file);
+        // Try to parse as different key types
+        let key = PrivateKeyDer::from_pem_reader(&mut key_reader).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to parse private key: {e}"),
+            )
+        })?;
 
-            // Try to parse as different key types
-            let key = rustls_pemfile::private_key(&mut key_reader)
-                .map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to parse private key: {e}"),
-                    )
-                })?
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidData, "No private key found")
-                })?;
-
-            config_builder
-                .with_client_auth_cert(certs, key)
-                .map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("Failed to set client auth: {e}"),
-                    )
-                })?
-        } else {
-            config_builder.with_no_client_auth()
-        };
-
-        Ok(RustlsConnector {
-            config: Arc::new(config),
-            verify_hostname: tls_config.verify_hostname,
+        builder.with_client_auth_cert(certs, key).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to set client auth: {e}"),
+            )
         })
     }
 

--- a/tests/integration/consumer_producer/mod.rs
+++ b/tests/integration/consumer_producer/mod.rs
@@ -3,12 +3,13 @@ pub use super::*;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use kafka::client::{FetchOffset, PartitionOffset};
+use kafka::client::{FetchOffset, KafkaClient, PartitionOffset};
 use kafka::consumer::Consumer;
 use kafka::producer::Record;
 use kafka::producer::{Producer, RequiredAcks};
 
 use rand::RngCore;
+use tracing::debug;
 
 const RANDOM_MESSAGE_SIZE: usize = 32;
 
@@ -84,7 +85,7 @@ pub fn test_consumer_with_client(mut client: KafkaClient) -> Consumer {
 /// the given producer.
 fn send_random_messages(producer: &mut Producer, topic: &str, num_messages: u32) {
     let mut random_message_buf = [0u8; RANDOM_MESSAGE_SIZE];
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     for _ in 0..num_messages {
         rng.fill_bytes(&mut random_message_buf);

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -4,15 +4,12 @@ extern crate kafka;
 #[cfg(feature = "integration_tests")]
 extern crate rand;
 
-#[cfg(feature = "integration_tests")]
-#[macro_use]
-extern crate lazy_static;
-
 #[allow(clippy::needless_borrow)]
 #[allow(unused_must_use)]
 #[cfg(feature = "integration_tests")]
 mod integration {
     use std::collections::HashMap;
+    use std::sync::LazyLock;
 
     use tracing::debug;
 
@@ -32,23 +29,21 @@ mod integration {
     const KAFKA_CLIENT_SECURE: &str = "KAFKA_CLIENT_SECURE";
     const KAFKA_CLIENT_COMPRESSION: &str = "KAFKA_CLIENT_COMPRESSION";
 
-    lazy_static! {
-        static ref COMPRESSIONS: HashMap<&'static str, Compression> = {
-            let mut m = HashMap::new();
+    static COMPRESSIONS: LazyLock<HashMap<&'static str, Compression>> = LazyLock::new(|| {
+        let mut m = HashMap::new();
 
-            m.insert("", Compression::NONE);
-            m.insert("none", Compression::NONE);
-            m.insert("NONE", Compression::NONE);
+        m.insert("", Compression::NONE);
+        m.insert("none", Compression::NONE);
+        m.insert("NONE", Compression::NONE);
 
-            m.insert("snappy", Compression::SNAPPY);
-            m.insert("SNAPPY", Compression::SNAPPY);
+        m.insert("snappy", Compression::SNAPPY);
+        m.insert("SNAPPY", Compression::SNAPPY);
 
-            m.insert("gzip", Compression::GZIP);
-            m.insert("GZIP", Compression::GZIP);
+        m.insert("gzip", Compression::GZIP);
+        m.insert("GZIP", Compression::GZIP);
 
-            m
-        };
-    }
+        m
+    });
 
     /// Constructs a Kafka client for the integration tests, and loads
     /// its metadata so it is ready to use.


### PR DESCRIPTION
cc @johnward 

## Summary
This PR modernizes the TLS backend by upgrading to `rustls` 0.23, replacing `rustls-pemfile` with `rustls-pki-types`, and introducing flexible crypto provider selection (`aws-lc-rs` vs `ring`).

## Key Changes

### Dependencies & Features
- **Upgraded `rustls`**: 0.21 -> 0.23.35.
- **Replaced `rustls-pemfile`**: Now using `rustls-pki-types` (v1.0) with `pem` feature.
- **New Feature Flags**:
  - `security-rustls-default`: Uses `aws-lc-rs` (Default).
  - `security-rustls-ring`: Uses `ring`.
  - `security`: Alias for `security-rustls-default`.

### Code Refactoring
- **`src/tls/rustls_connector.rs`**:
  - Refactored `new()` method to eliminate `clippy::too_many_lines`.
  - Implemented logic to select the crypto provider based on feature flags.
  - Fixed `ClientConfig` builder chain (added `with_safe_default_protocol_versions`).
- **`src/producer.rs` & `src/consumer/builder.rs`**:
  - Updated `cfg` attributes to support the new feature flag structure.

### Documentation
- **`README.md`**: Added migration guide, crypto provider selection instructions, and TLS version support notes.
- **`CHANGELOG.md`**: Updated `[Unreleased]` section with detailed changes.

## Breaking Changes
- The default `security` feature now uses `rustls` (with `aws-lc-rs`) instead of OpenSSL.
- Users relying on `rustls-pemfile` types via this crate's internal API should migrate to `rustls-pki-types`.

https://github.com/kafka-rust/kafka-rust/pull/248#issuecomment-3772364924